### PR TITLE
Refactor: Rename Aleph.im and Twentysix Cloud References, Update Links, and Enforce Absolute Asset Paths

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,7 +62,7 @@ export default defineConfig({
         }
       ],
       
-      // About section sidebar (previous "What is Aleph.im?")
+      // About section sidebar (previous "What is Aleph Cloud?")
       '/about/': [
         {
           text: 'About Aleph Cloud',
@@ -344,7 +344,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/vuejs/vitepress' }
+      { icon: 'github', link: 'https://github.com/aleph-im' }
     ]
   }
 })

--- a/docs/.vitepress/version.json
+++ b/docs/.vitepress/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v1.0.0-bd48334",
+  "version": "v1.0.0-36ec558",
   "isLocal": true,
   "localUrl": "http://localhost:5173",
-  "buildTime": "2025-04-30T12:06:46.754Z"
+  "buildTime": "2025-05-02T12:07:02.286Z"
 }

--- a/docs/about/how-it-works/index.md
+++ b/docs/about/how-it-works/index.md
@@ -28,9 +28,6 @@ The first payment implementation is achieved through a staking mechanism,
 where users must hold a certain amount of ALEPH tokens to use the network's resources.
 This mechanism is in place for file storage and for persistent virtual machines.
 
-In January 2024, the network started supporting a new payment model, together with the launch
-of the [TwentySix Cloud](https://www.twentysix.cloud/) platform,
-where users pay using streams of ALEPH tokens on compatible chains.
 
 ## Example Workflow
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -34,5 +34,5 @@ by leveraging the Aleph Cloud network's decentralized storage and compute capabi
 ## Community
 
 - Found an issue? [Report it here](https://github.com/aleph-im/support/issues).
-- Chat on our [Telegram group](https://t.me/alephim).
+- Chat on our [Telegram group](https://t.me/alephcloud).
 - Engage on our [Discourse Channel](https://community.aleph.cloud/).

--- a/docs/about/network/supported-blockchains/index.md
+++ b/docs/about/network/supported-blockchains/index.md
@@ -1,27 +1,27 @@
 # Supported Chains
 
-Multiple blockchains are supported when interacting with aleph.im.
+Multiple blockchains are supported when interacting with Aleph Cloud.
 
 The support of a chain consists in the functionalities below. 
 The support of a chain may be partial, when only some of these 
 functionalities are supported.
 
 1. **Message signature**:
-   Messages on the aleph.im network must be signed using asymmetric a user's private key.
+   Messages on the Aleph Cloud network must be signed using asymmetric a user's private key.
    Different chains may use public-key cryptography differently, resulting in different methods
    of verifying message signatures.
 2. **Wallet support**:
-   Interacting with aleph.im in a browser and signing messages requires the use of a Wallet application. 
+   Interacting with Aleph Cloud in a browser and signing messages requires the use of a Wallet application. 
    These applications are often specific to one or a few chains.
 3. **Token availability**:
-   Allocating resources on the aleph.im network relies on a fungible onchain token.
+   Allocating resources on the Aleph Cloud network relies on a fungible onchain token.
    Exchanging that token on a blockchain requires that token to be available on that chain first. 
 4. **Balance support**:
-   The aleph.im network needs to be aware of user's tokens on each supported chain in order to allow
+   The Aleph Cloud network needs to be aware of user's tokens on each supported chain in order to allow
    users to allocate resources on the network. Some services are not available without balance support.
 5. **Staking support**:
-   Users can help securing the aleph.im network by holding tokens and _staking_ them on 
-   [Core Channel Nodes](/nodes/core/introduction/) they consider trustworthy. The aleph.im network
+   Users can help securing the Aleph Cloud network by holding tokens and _staking_ them on 
+   [Core Channel Nodes](/nodes/core/introduction/) they consider trustworthy. The Aleph Cloud network
    interacts with blockchains to achieve this mechanism.
 6. **PAYG support**:
    Users can pay for network resources in real-time by streaming tokens for the duration of their usage. When they open

--- a/docs/about/resources/community/index.md
+++ b/docs/about/resources/community/index.md
@@ -12,9 +12,9 @@ The Aleph Cloud community is active across various platforms. This page provides
 
 ### Discussion Forums
 
-- [Telegram Group](https://t.me/alephim) - Main community chat
-- [Discourse Forum](https://community.aleph.im/) - Technical discussions and announcements
-- [Discord Server](https://discord.gg/aleph-im) - Developer community
+- [Telegram Group](https://t.me/alephcloud) - Main community chat
+- [Discourse Forum](https://community.aleph.cloud/) - Technical discussions and announcements
+- [Discord Server](https://discord.com/invite/alephcloud) - Developer community
 
 ## Support
 
@@ -28,9 +28,9 @@ The Aleph Cloud community is active across various platforms. This page provides
 
 ## Node Operator Resources
 
-- [Node and Staking Dashboard](https://account.aleph.im/) - Manage your nodes
+- [Node and Staking Dashboard](https://app.aleph.cloud/account) - Manage your nodes
 - [Node Documentation](/nodes/) - Setup and maintenance guides
-- [Node Operator Chat](https://t.me/alephim/123724/) - Dedicated support for node operators
+- [Node Operator Chat](https://t.me/alephcloud/123724/) - Dedicated support for node operators
 
 
 ## Events
@@ -40,8 +40,8 @@ The Aleph Cloud community is active across various platforms. This page provides
 
 ## Educational Resources
 
-- [Blog](https://twentysix.cloud/blog/) - Articles and updates from the Aleph Cloud team
-- [Case Studies](https://www.twentysix.cloud/blog/articles/champions-tactics-aleph-vrf/) - Examples of Aleph Cloud in production
+- [Blog](https://www.aleph.cloud/blog/) - Articles and updates from the Aleph Cloud team
+- [Case Studies](https://www.aleph.cloud/blog/articles/champions-tactics-aleph-vrf/) - Examples of Aleph Cloud in production
 - <a href="https://link" style="color: #ff6666;">Tutorials</a> - Step-by-step guides for developers
 
 ## Getting Involved

--- a/docs/about/resources/faq/index.md
+++ b/docs/about/resources/faq/index.md
@@ -4,17 +4,13 @@
 
 ### Aleph
 
-- Web: [https://aleph.im](https://aleph.im)
-- Forum: [https://community.aleph.im](https://community.aleph.im)
+- Web: [https://aleph.cloud](https://aleph.cloud)
+- Forum: [https://community.aleph.cloud](https://community.aleph.cloud)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
 - Twitter: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
 - Linkedin: [https://www.linkedin.com/company/aleph-im](https://www.linkedin.com/company/aleph-im)
-- Telegram: [https://t.me/alephim](https://t.me/alephim)
+- Telegram: [https://t.me/alephcloud](https://t.me/alephcloud)
 
-### Twentysix Cloud
-
-- Web: [https://www.twentysix.cloud/](https://www.twentysix.cloud/)
-- Twitter: [https://twitter.com/twentysixcloud](https://twitter.com/twentysixcloud)
 
 ### $ALEPH Token Contracts/Mint addresses
 
@@ -24,22 +20,17 @@
 - **Solana**: [`3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x`](https://solana.fm/address/3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x)
 - **BASE**: [`0xc0Fbc4967259786C743361a5885ef49380473dCF`](https://basescan.org/token/0xc0Fbc4967259786C743361a5885ef49380473dCF)
 
-## General Questions
-
-::: details What is Twentysix Cloud?
-Twentysix Cloud is a cross-chain cloud solution that provides scalable, high-performance resources for applications, particularly in AI, DeFi, and gaming. It is powered by the decentralized Aleph.im network. Learn more at [Twentysix Cloud](https://www.twentysix.cloud/).
-:::
 
 ## Staking
 
 ### Basics
 
 ::: details Where can I stake my $ALEPH?
-You can stake your $ALEPH at [Aleph Account](https://account.aleph.im/).
+You can stake your $ALEPH at [Aleph Cloud Account](https://account.aleph.cloud/).
 :::
 
 ::: details Is there a staking tutorial?
-Yes, check out our [Aleph.im Staking Guide](https://medium.com/aleph-im/aleph-im-staking-guide-9b82264968be).
+Yes, check out our [Aleph Cloud Staking Guide](https://medium.com/aleph-im/aleph-im-staking-guide-9b82264968be).
 :::
 
 ::: details What are the staking tokenomics for stakers?
@@ -67,7 +58,7 @@ No, there is currently no cap on the amount staked on a single node.
 ### Rewards & Returns
 
 ::: details How many ALEPH will I get for staking?
-Use the calculator at the top section of the [web app](https://account.aleph.im/) to estimate your staking rewards.
+Use the calculator at the top section of the [web app](https://app.aleph.cloud/account) to estimate your staking rewards.
 :::
 
 ::: details When are the staking rewards paid?
@@ -85,7 +76,7 @@ No, the total amount staked per node does not affect individual staker rewards.
 ### Security & Flexibility
 
 ::: details Are my funds safe when I stake?
-Yes, staking on Aleph.im is non-custodial. Your tokens remain in your wallet with no lock-up period.
+Yes, staking on Aleph Cloud is non-custodial. Your tokens remain in your wallet with no lock-up period.
 :::
 
 ::: details Is there a required lock-up period to stake?
@@ -123,7 +114,7 @@ Yes, TrustWallet can be connected via WalletConnect.
 :::
 
 ::: details Can I stake with the NULS or NEO variant of the ALEPH token?
-No, you must convert NULS or NEO variants to the ERC-20 variant of ALEPH at [Aleph Swap](https://swap.aleph.im) before staking.
+No, you must convert NULS or NEO variants to the ERC-20 variant of ALEPH at [Aleph Swap](https://swap.aleph.cloud) before staking.
 :::
 
 ### Node Selection
@@ -143,7 +134,7 @@ Purchase ALEPH v2 on platforms such as Coinbase, KuCoin, Gate, LATOKEN, MEXC, Un
 :::
 
 ::: details What is Pay-As-You-Go?
-Pay-As-You-Go allows you to pay for resources as you use them on the Aleph.im network, eliminating the need to hold or stake large amounts of $ALEPH. This is currently available on BASE and Avalanche c-chain. More chains will be supported in the future, refer to the [supported chains](/about/network/supported-blockchains/) table.
+Pay-As-You-Go allows you to pay for resources as you use them on the Aleph Cloud network, eliminating the need to hold or stake large amounts of $ALEPH. This is currently available on BASE and Avalanche c-chain. More chains will be supported in the future, refer to the [supported chains](/about/network/supported-blockchains/) table.
 :::
 
 ## Node Operators

--- a/docs/about/use-cases/index.md
+++ b/docs/about/use-cases/index.md
@@ -18,7 +18,7 @@ description: Explore real-world applications and success stories powered by Alep
     </div>
     <div class="vp-card-content">
       <h3>Ubisoft</h3>
-      <p>Aleph.im partnered with Ubisoft's Innovation Lab to integrate dynamic NFTs in "Tom Clancy's Ghost Recon Breakpoint" and "Champions Tactics". Aleph.im provided decentralized storage for NFTs, enabling unique in-game assets that players could claim, use, and trade on secondary markets.</p>
+      <p>Aleph Cloud partnered with Ubisoft's Innovation Lab to integrate dynamic NFTs in "Tom Clancy's Ghost Recon Breakpoint" and "Champions Tactics". Aleph Cloud provided decentralized storage for NFTs, enabling unique in-game assets that players could claim, use, and trade on secondary markets.</p>
       <div class="vp-card-footer">
         <a href="https://championstactics.ubisoft.com/" target="_blank" rel="noopener noreferrer">Learn more →</a>
       </div>
@@ -31,7 +31,7 @@ description: Explore real-world applications and success stories powered by Alep
     </div>
     <div class="vp-card-content">
       <h3>LibertAI</h3>
-      <p>LibertAI leverages Aleph.im's infrastructure to create decentralized AI models. Their large language models run on a combination of IPFS and TwentySix Cloud, creating a fully decentralized, uncensored, secure, and resilient computing network that ensures user privacy and data integrity.</p>
+      <p>LibertAI leverages Aleph Cloud's infrastructure to create decentralized AI models. Their large language models run on a combination of IPFS and Aleph Cloud, creating a fully decentralized, uncensored, secure, and resilient computing network that ensures user privacy and data integrity.</p>
       <div class="vp-card-footer">
         <a href="https://libertai.io/" target="_blank" rel="noopener noreferrer">Explore the future of AI →</a>
       </div>
@@ -44,7 +44,7 @@ description: Explore real-world applications and success stories powered by Alep
     </div>
     <div class="vp-card-content">
       <h3>Request Finance</h3>
-      <p>Aleph.im collaborated with Request Network, the invoicing technology for DeFi, DAOs, and crypto-first companies. Aleph.im bridged Request's dedicated IPFS network and the IPFS public network, providing backup storage for invoicing and transaction data.</p>
+      <p>Aleph Cloud collaborated with Request Network, the invoicing technology for DeFi, DAOs, and crypto-first companies. Aleph Cloud bridged Request's dedicated IPFS network and the IPFS public network, providing backup storage for invoicing and transaction data.</p>
       <div class="vp-card-footer">
         <a href="https://medium.com/aleph-im/aleph-im-partners-with-request-network-to-expand-their-decentralized-storage-of-invoicing-data-on-359bbb2d3a0c" target="_blank" rel="noopener noreferrer">Read the case study →</a>
       </div>
@@ -138,4 +138,4 @@ Connect and operate across multiple blockchain ecosystems:
 
 ## Get Started with Aleph Cloud
 
-Ready to build on Aleph Cloud's decentralized infrastructure? Check out our [developer documentation](/devhub/) or explore [TwentySix Cloud](https://www.twentysix.cloud/) to start building your application today.
+Ready to build on Aleph Cloud's decentralized infrastructure? Check out our [developer documentation](/devhub/) or explore [Aleph Cloud](https://app.aleph.cloud/) to start building your application today.

--- a/docs/devhub/building-applications/blockchain-data/indexing/evm-indexer.md
+++ b/docs/devhub/building-applications/blockchain-data/indexing/evm-indexer.md
@@ -151,13 +151,13 @@ export default class MainDomain extends IndexerMainDomain {
     await super.init()
     await this.indexAccounts([
       {
-        // The `Aleph.im v2` ERC20 token contract on the network with id `ethereum-mainnet`
+        // The `Aleph Cloud v2` ERC20 token contract on the network with id `ethereum-mainnet`
         blockchainId: 'ethereum-mainnet',
         account: '0x27702a26126e0B3702af63Ee09aC4d1A084EF628',
         index: { logs: true },
       },
       {
-        // The `Aleph.im v2` ERC20 token contract on the network with id `ethereum-testnet`
+        // The `Aleph Cloud v2` ERC20 token contract on the network with id `ethereum-testnet`
         blockchainId: 'ethereum-testnet',
         account: '0xC751491ae7dec5139a219d6094EF3fAd540A6de1',
         index: { logs: true },
@@ -586,15 +586,14 @@ This structure supports a clear separation of concerns, making it easier to mana
 This guide has walked you through setting up an indexer for the ethereum blockchain, from initializing the project and configuring the indexer to storing event data and exposing it through a GraphQL API. With the provided structure and examples, you're well-equipped to customize and extend your indexer to suit your specific needs, whether by adding more blockchain networks, optimizing performance, or enhancing security.
 
 ### 10.1 Additional resources
-- Development support: [https://t.me/alephim/119590](https://t.me/alephim/119590)
+- Development support: [https://t.me/alephcloud/119590](https://t.me/alephcloud/119590)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
-- Infrastructure documentation: [docs.aleph.im](https://docs.aleph.im)
-- Web3 Cloud: [console.twentysix.cloud](https://console.twentysix.cloud)
+- Infrastructure documentation: [docs.aleph.cloud](https://docs.aleph.cloud)
+- Web3 Cloud: [app.aleph.cloud](https://app.aleph.cloud)
 
 ### 10.2 Social
-- X twentysix.cloud: [https://twitter.com/TwentySixCloud](https://twitter.com/TwentySixCloud)
-- X aleph.im: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
-- Community: [https://t.me/alephim](https://t.me/alephim)
+- X aleph.cloud: [https://twitter.com/aleph_im](https://twitter.com/aleph_cloud)
+- Community: [https://t.me/alephcloud](https://t.me/alephcloud)
 - Medium: [https://medium.com/aleph-im](https://medium.com/aleph-im)
 
 ## 11 Example indexing other EVM networks (oasys homeverse)

--- a/docs/devhub/building-applications/blockchain-data/indexing/index.md
+++ b/docs/devhub/building-applications/blockchain-data/indexing/index.md
@@ -1,6 +1,6 @@
 # Indexing Framework
 
-The [aleph.im Indexer Framework](https://github.com/aleph-im/aleph-indexer-framework) is a node.js and [moleculer](https://moleculer.services/) based framework for building multithreaded indexers to be deployed on the Aleph.im network. It provides a scalable architecture for tracking and processing blockchain events across multiple networks simultaneously.
+The [Aleph Cloud Indexer Framework](https://github.com/aleph-im/aleph-indexer-framework) is a node.js and [moleculer](https://moleculer.services/) based framework for building multithreaded indexers to be deployed on the Aleph Cloud network. It provides a scalable architecture for tracking and processing blockchain events across multiple networks simultaneously.
 
 ## Overview
 

--- a/docs/devhub/building-applications/blockchain-data/indexing/solana-idl-indexer.md
+++ b/docs/devhub/building-applications/blockchain-data/indexing/solana-idl-indexer.md
@@ -72,7 +72,7 @@ npm run start
 
 If you wait for a moment you will see a message warning you that it is now running a GraphQL server on [http://localhost:8080](http://localhost:8080).
 
-## Deploying your Indexer to Aleph.im
+## Deploying your Indexer to Aleph Cloud
 To deploy your indexer, read this [documentation](https://github.com/aleph-im/aleph-indexer-library?tab=readme-ov-file#building-and-deploying-an-indexer)
 
 ## Supported Queries
@@ -514,4 +514,4 @@ It is generally not advised to modify these files, as they are generated from th
 The Aleph Indexer Generator simplifies the process of creating Solana indexers by generating all necessary boilerplate code.
 It provides a solid foundation for building a Solana indexer and can be extended with additional functionality following the provided architecture or the [EVM Indexer Guide](evm-indexer.md).
 
-If you have any questions or need help with the indexer generator, feel free to reach out to us on [Telegram](https://t.me/alephim) or open an issue on the [GitHub repository](https://github.com/aleph-im/aleph-indexer-library/issues).
+If you have any questions or need help with the indexer generator, feel free to reach out to us on [Telegram](https://t.me/alephcloud) or open an issue on the [GitHub repository](https://github.com/aleph-im/aleph-indexer-library/issues).

--- a/docs/devhub/building-applications/data-storage/types-of-storage/immutable-volume.md
+++ b/docs/devhub/building-applications/data-storage/types-of-storage/immutable-volume.md
@@ -24,7 +24,7 @@ Additional data can be provided to a program by bundling it in an immutable volu
 mksquashfs ./custom-data data.squashfs
 ```
 
-### 2. Publish the file on aleph.im
+### 2. Publish the file on aleph cloud
 
 ```shell
 aleph file upload ./data.squashfs
@@ -51,7 +51,7 @@ pip3 install -t ./packages -r ./requirements.txt
 mksquashfs ./packages packages.squashfs
 ```
 
-### 3. Publish the file on aleph.im
+### 3. Publish the file on aleph cloud
 
 ```shell
 aleph file upload ./packages.squashfs

--- a/docs/devhub/building-applications/messaging/index.md
+++ b/docs/devhub/building-applications/messaging/index.md
@@ -1,26 +1,26 @@
 # Messages
 
-At its core, the aleph.im network is a messaging system.
-All the data that transits on the network is represented by aleph.im messages that represent
+At its core, the aleph cloud network is a messaging system.
+All the data that transits on the network is represented by aleph cloud messages that represent
 all the possible operations on the network.
 
-With aleph.im messages, you can, for example:
+With aleph cloud messages, you can, for example:
 
 * store files
 * pin content on IPFS
 * create decentralized programs
 * set up key/value databases.
 
-Users create, sign and transmit messages to the aleph.im network.
+Users create, sign and transmit messages to the aleph cloud network.
 This can be achieved in a variety of ways:
 
 * by posting a message to a Core Channel Node
-* by broadcasting the message on the aleph.im peer-to-peer network
-* by using the aleph.im smart contracts deployed on supported chains.
+* by broadcasting the message on the aleph cloud peer-to-peer network
+* by using the aleph cloud smart contracts deployed on supported chains.
 
 ## Message format
 
-An aleph.im message is made of multiple fields that can be split between header and content fields.
+An aleph cloud message is made of multiple fields that can be split between header and content fields.
 
 ### Header fields
 
@@ -59,7 +59,7 @@ Messages are uniquely identified by the `item_hash` field.
 This value is obtained by computing the hash of the `content` field. 
 Currently, the hash can be obtained in one of two ways. 
 If the content of the message is stored on IPFS, the `item_hash` of the message will be the CIDv0 of this content. 
-Otherwise, if the message is stored on aleph.im native storage or is included in the message, the item hash will be 
+Otherwise, if the message is stored on aleph cloud native storage or is included in the message, the item hash will be 
 the SHA256 hash of the message in hexadecimal encoding. 
 In the first case, the item type will be set to `ipfs`. 
 In the second case, the item type will either be `inline` if the content is included in the message (serialized as a

--- a/docs/devhub/building-applications/messaging/object-types/forget.md
+++ b/docs/devhub/building-applications/messaging/object-types/forget.md
@@ -1,9 +1,9 @@
 # Deleting messages
 
-The aleph.im protocol is GDPR-compliant.
+The aleph cloud protocol is GDPR-compliant.
 To achieve this objective, we allow users to delete their own data.
 This is implemented using a special message type called FORGET.
-By sending a FORGET message, users can delete one or more messages from the entire aleph.im network.
+By sending a FORGET message, users can delete one or more messages from the entire aleph cloud network.
 Users can forget any type of message, except for FORGET messages themselves.
 
 When a FORGET message is processed by a node, it will immediately mark the target message(s) as forgotten,

--- a/docs/devhub/building-applications/messaging/object-types/programs.md
+++ b/docs/devhub/building-applications/messaging/object-types/programs.md
@@ -1,6 +1,6 @@
 # Programs
 
-PROGRAM messages create a new application that can then be run on aleph.im VMs.
+PROGRAM messages create a new application that can then be run on aleph cloud VMs.
 
 ## Content format
 
@@ -32,7 +32,7 @@ The `content` field of a PROGRAM message must contain the following fields:
 },
 "runtime": {
   "address": "0x4cB66fDf10971De5c7598072024FFd33482907a5",
-  "comment": "Aleph.im Alpine Linux with Python 3.8"
+  "comment": "Aleph Cloud Alpine Linux with Python 3.8"
 },
 "data": {
   "encoding": "tar.gzip",

--- a/docs/devhub/building-applications/messaging/object-types/store.md
+++ b/docs/devhub/building-applications/messaging/object-types/store.md
@@ -1,14 +1,14 @@
 # File storage
 
-Users can store files on the aleph.im network using STORE messages. 
+Users can store files on the aleph cloud network using STORE messages. 
 By publishing a STORE message, users can:
 
-* store a file in the native aleph.im storage system
-* pin an IPFS CID on the aleph.im network.
+* store a file in the native aleph cloud storage system
+* pin an IPFS CID on the aleph cloud network.
 
-STORE messages tell the aleph.im network to store data on behalf of the
+STORE messages tell the aleph cloud network to store data on behalf of the
 user. The data can either be pinned to IPFS or stored in the native
-aleph.im storage system depending on the content item type.
+aleph cloud storage system depending on the content item type.
 
 ## STORE message content format
 
@@ -24,7 +24,7 @@ following fields:
 
 ## Updating files
 
-While files on the aleph.im network are immutable, you can use the `ref` field of STORE messages to create
+While files on the aleph cloud network are immutable, you can use the `ref` field of STORE messages to create
 a virtual filename and update it.
 
 When posting a STORE message, you can specify a value of your own liking to the `ref` field (ex: `ref: my-dynamic-nft`).
@@ -33,5 +33,5 @@ If you do not specify a value, it is automatically set to the item hash of the S
 From that point, you can then update your file by sending additional STORE messages with the same `ref` value.
 These messages will be considered as updates of the original.
 
-> Updating a file does not delete the previous versions. Each file is preserved on the aleph.im network until you emit
+> Updating a file does not delete the previous versions. Each file is preserved on the aleph cloud network until you emit
 > a FORGET message targeting these files.

--- a/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
+++ b/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
@@ -192,6 +192,6 @@ aleph instance confidential-init-session <vm_hash> --debug
 
 If you've tried the solutions above and are still experiencing issues:
 
-1. Join the [Aleph Cloud Discord](https://discord.gg/alephim) for community support
+1. Join the [Aleph Cloud Discord](https://discord.com/invite/alephcloud) for community support
 2. Open an issue on the [Aleph-VM GitHub repository](https://github.com/aleph-im/aleph-vm/issues)
-3. Contact the Aleph Cloud team directly through the [official website](https://aleph.im/contact)
+3. Contact the Aleph Cloud team directly through the [official website](https://aleph.cloud/contact)

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
@@ -2,7 +2,7 @@
 
 Many Python programs require additional packages beyond those present on the system by default.
 While you could of course create your own runtime, there is a faster and easier solution.
-The official aleph.im Python runtimes automatically includes `/opt/packages` in the Python search path (`PYTHONPATH`). Mounting a volume on this path will make any Python module or package present in that volume importable from your program.
+The official Aleph Cloud Python runtimes automatically includes `/opt/packages` in the Python search path (`PYTHONPATH`). Mounting a volume on this path will make any Python module or package present in that volume importable from your program.
 
 Using a dedicated volume for your dependencies has several advantages:
 
@@ -47,8 +47,8 @@ mksquashfs ./my-packages packages.squashfs
 
 ## Upload the dependency volume
 
-To use this volume inside a program, we need the aleph.im message hash storing
-this volume, meaning that we need to upload the volume to aleph.im first.
+To use this volume inside a program, we need the Aleph Cloud message hash storing
+this volume, meaning that we need to upload the volume to Aleph Cloud first.
 
 ### Without IPFS (small size)
 
@@ -95,7 +95,7 @@ Finally, press Enter to skip adding more volumes.
 Add volume ? [y/N]
 ```
 
-Your program should be uploaded on aleph.im.
+Your program should be uploaded on Aleph Cloud.
 
 ## [macOS] Set up your environment with Vagrant
 

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
@@ -1,6 +1,6 @@
 # Advanced Python program features
 
-## Aleph.im messages
+## Aleph Cloud messages
 
 The [aleph-sdk-python](https://github.com/aleph-im/aleph-sdk-python) library is pre-installed and 
 pre-configured in the official Aleph-VM Python runtime. It is tweaked to work even
@@ -8,7 +8,7 @@ for programs with the access to internet disabled.
 
 ### Get messages
 
-Use `aleph.sdk.client.AlephHttpClient` to get messages from the aleph.im network.
+Use `aleph.sdk.client.AlephHttpClient` to get messages from the Aleph Cloud network.
 
 ```python
 from aleph.sdk.client import AlephHttpClient
@@ -24,11 +24,11 @@ async def get_messages():
         return resp.messages
 ```
 
-## Post Aleph.im messages
+## Post Aleph Cloud messages
 
-Messages posted by VMs may not be authorized by the aleph.im network yet.
+Messages posted by VMs may not be authorized by the Aleph Cloud network yet.
 
-Posting messages on the aleph.im network requires signing them using a valid account.
+Posting messages on the Aleph Cloud network requires signing them using a valid account.
 Since programs are public, they should not contain secrets. Instead of signing messages
 themselves, programs should therefore ask their execution host to sign messages on their behalf
 using a `RemoteAccount`. The hash of the VM will be referenced in the message content `address` 
@@ -67,7 +67,7 @@ be useful to persist between executions but can be recovered from other sources.
 The cache is specific to one program on one execution node.
 
 The persistence of the cache should not be relied on - its content can be deleted anytime when
-the program is not running. Important data must be persisted on the aleph.im network. 
+the program is not running. Important data must be persisted on the Aleph Cloud network. 
 
 To use the cache, you can use the following methods:
 ```python
@@ -88,7 +88,7 @@ started.
 
 ### Immutable volumes
 
-Immutable volumes contain extra files that can be used by a program and are stored on the aleph.im 
+Immutable volumes contain extra files that can be used by a program and are stored on the Aleph Cloud 
 network. They can be shared by multiple programs and updated independently of the code of the program.
 
 You can use them to store Python libraries that your program depends on, use them in multiple
@@ -115,7 +115,7 @@ ipfs add extra-lib.squashfs
 ```
 and retrieve the printed IPFS hash.
 
-Pin the volume on aleph.im using `aleph pin`:
+Pin the volume on Aleph Cloud using `aleph pin`:
 ```shell
 aleph pin $IPFS_HASH --channel TEST
 ```
@@ -140,7 +140,7 @@ Like the cache, host persistent volumes are specific to one program on one execu
 Unlike the cache, you can use these volumes to store any kind of files, including databases.
 
 There is no guarantee that these volumes will not be deleted anytime when the
-program is not running and important data must be persisted on the aleph.im network.
+program is not running and important data must be persisted on the Aleph Cloud network.
 
 Host persistent volumes have a fixed size and must be named. The name will be used in the future
 to allow changing the mount point of a volume.

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
@@ -1,9 +1,9 @@
 # Build a Python microVM
 
-This tutorial will guide you through the steps of building a Python microVM to run on the aleph.im network.
+This tutorial will guide you through the steps of building a Python microVM to run on the Aleph Cloud network.
 We will build a simple HTTP server and add features as we go.
 
-> ℹ This tutorial uses the aleph.im command line interface.
+> ℹ This tutorial uses the Aleph Cloud command line interface.
 
 ## Requirements
 
@@ -15,12 +15,12 @@ enough to get started.
 To complete this tutorial, you will use the `aleph` command from 
 [aleph-client](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on 
-aleph.im.
+Aleph Cloud.
 
 First, you need a recent version of Python and [pip](https://pip.pypa.io/en/stable/), 
 preferably running on Debian 11 or Ubuntu 20.04.
 
-Some cryptographic functionalities of aleph.im use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+Some cryptographic functionalities of Aleph Cloud use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 Archiving programs and volumes requires
 [Squashfs user space tools](https://github.com/plougher/squashfs-tools).
 
@@ -36,7 +36,7 @@ brew install libsecp256k1 squashfs
 ```
 
 You will also need [Uvicorn](https://www.uvicorn.org/) for local testing 
-and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+and the [Python Aleph Cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
 
 - Linux/macOs:
 
@@ -44,15 +44,15 @@ and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for i
 pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
 ```
 
-## Understanding aleph.im programs
+## Understanding Aleph Cloud programs
 
-Aleph.im programs are applications running on the aleph.im network.
+Aleph Cloud programs are applications running on the Aleph Cloud network.
 Each program defines the application to be executed, data to use, computing requirements 
 (number of CPUs, amount of RAM) and many more parameters.
 
 Each program is instantiated as a __virtual machine__ running on a Compute Resource Node (CRN).
 Virtual machines are emulated computer systems with dedicated resources that run isolated from each other.
-Aleph.im Virtual Machines (VMs) are based on Linux.
+Aleph Cloud Virtual Machines (VMs) are based on Linux.
 
 We support two types of allocation: _on-demand_ and _persistent_. 
 _on-demand_ boot extremely fast and can be launched on demand. They are perfect for lightweight applications
@@ -69,14 +69,14 @@ one tenth of the $ALEPH tokens to hold, compared to a [Persistent VM](#persisten
 
 The base of each VM is a Linux 
 [root filesystem](https://en.wikipedia.org/wiki/Root_directory) named __runtime__ and configured
-to run programs on the aleph.im platform. 
+to run programs on the Aleph Cloud platform. 
 
-Aleph.im provides a supported runtime to launch programs written in Python or binaries. 
+Aleph Cloud provides a supported runtime to launch programs written in Python or binaries. 
 
 - Python programs must support the [ASGI interface](https://asgi.readthedocs.io/en/latest/), described in the example below.
 - Binaries must listen for HTTP requests on port 8080
 
-You can find runtimes currently supported by aleph.im [here](/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes).
+You can find runtimes currently supported by Aleph Cloud [here](/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes).
 
 ### Volumes
 
@@ -92,7 +92,7 @@ more memory.
 **Host persistent volumes** are persisted on the VM execution node, but may be garbage collected
 by the node without warning.
 
-**Store persistent volumes** (not available yet) are persisted on the aleph.im network. 
+**Store persistent volumes** (not available yet) are persisted on the Aleph Cloud network. 
 New VMs will try to use the latest version of this volume, with no guarantee against conflicts.
 
 ## Write a Python program
@@ -125,9 +125,9 @@ Have a look at it for a better understanding of what it does and how it works.
 
 ## Test it locally
 
-Before uploading your program on aleph.im, let's test it on your machine.
+Before uploading your program on Aleph Cloud, let's test it on your machine.
 
-Aleph.im uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
+Aleph Cloud uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
 interface with programs written in Python. ASGI interfaces with many Python frameworks, including
 FastAPI but also [Django](https://www.djangoproject.com/) 
 or [Quart](https://github.com/pgjones/quart).
@@ -160,7 +160,7 @@ The `--reload` option will automatically reload your app when the code changes.
 > ℹ Installing uvicorn should add the `uvicorn` command to your shell. If it does not, use
 > `python -m uvicorn` to run it.
 
-## Upload your program on aleph.im
+## Upload your program on Aleph Cloud
 
 After installing [aleph-client](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
 
@@ -186,19 +186,19 @@ Ref of runtime ? [bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29
 
 You should then get a response similar to the following: 
 ```
-Your program has been uploaded on aleph.im .
+Your program has been uploaded on Aleph Cloud .
 
 Available on:
   https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
 Visualise on:
-  https://explorer.aleph.im/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
 You may get the warning `Message failed to publish on IPFS and/or P2P`. 
 This is common and usually not an issue.
 
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph.im identifiers are too long to work
+> ℹ The second URL uses a hostname dedicated to your VM. Aleph Cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [Custom Domain](/devhub/deploying-and-hosting/custom-domains/setup) section.
@@ -209,12 +209,12 @@ You can now run your program by opening one of the URLs above. Each URL is uniqu
 
 https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 
-This will automatically start your program inside a VM on the aleph.im Compute Resource Node behind
+This will automatically start your program inside a VM on the Aleph Cloud Compute Resource Node behind
 the `aleph.sh` domain name and serve your request.
 
 An important thing to notice is that we did not install any specific dependency for our program,
 despite relying on FastAPI.
-This is because the official aleph.im runtime is already pre-configured with several typical Python packages.
+This is because the official Aleph Cloud runtime is already pre-configured with several typical Python packages.
 Of course, you can customize your program to add your own requirements.
 Refer to [Adding Python dependencies to a program](/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes) for more information.
 

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/rust.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/rust.md
@@ -2,14 +2,14 @@
 
 > This tutorial follows up the first tutorial [Creating and hosting a Python program on Aleph-VM](/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/).
 
-In this tutorial, we will build and deploy a Rust application on the aleph.im network.
+In this tutorial, we will build and deploy a Rust application on the Aleph Cloud network.
 
 In addition to running Python programs using ASGI as covered in the first tutorial, 
-Aleph.im VMs also support any program as long as it listens for HTTP requests on port 8080.
+Aleph Cloud VMs also support any program as long as it listens for HTTP requests on port 8080.
 
 ## The application
 
-In this first section, you will run a program written in Rust on an aleph.im VM.
+In this first section, you will run a program written in Rust on an Aleph Cloud VM.
 
 ### Requirements
 
@@ -74,7 +74,7 @@ cargo run
 
 Open `http://127.0.0.1:8080` in your browser to test your new server.
 
-## Upload your program on aleph.im
+## Upload your program on Aleph Cloud
 
 Let's upload our program.
 

--- a/docs/devhub/compute-resources/functions/advanced/test-programs.md
+++ b/docs/devhub/compute-resources/functions/advanced/test-programs.md
@@ -1,6 +1,6 @@
 # How to test your Function (Program) locally
 
-You can test your Function locally without uploading each version on the aleph.im network.
+You can test your Function locally without uploading each version on the aleph.cloud network.
 
 To do this, you'll want to use the `--fake-data-program` or `-f` argument of the VM Supervisor.
 
@@ -55,7 +55,7 @@ python -m vm_supervisor --print-settings --very-verbose --system-logs --fake-dat
 
 ### 2.a. Install the system requirements
 
-Refer to [the aleph.im VM supervisor documentation](https://github.com/aleph-im/aleph-vm/blob/main/vm_supervisor/README.md) to install the system requirements.
+Refer to [the aleph.cloud VM supervisor documentation](https://github.com/aleph-im/aleph-vm/blob/main/vm_supervisor/README.md) to install the system requirements.
 
 ### 2.b. Run the supervisor with fake data:
 

--- a/docs/devhub/compute-resources/functions/advanced/update-programs.md
+++ b/docs/devhub/compute-resources/functions/advanced/update-programs.md
@@ -3,7 +3,7 @@
 Whether it is to add new features to your application, upgrade to the latest version of a dependency or migrate to
 a new runtime, there are numerous reasons why you will update your program.
 
-In this tutorial, we will see how you can, and sometimes cannot, update programs deployed on the aleph.im network.
+In this tutorial, we will see how you can, and sometimes cannot, update programs deployed on the Aleph Cloud network.
 
 There are two main solutions to update a program:\
 1. Update the program directly\
@@ -54,7 +54,7 @@ of its volumes.
 There are numerous cases where this is the best option:
 
 * You detected a security vulnerability in one of your dependencies and want to migrate to a fixed version
-* You want your program to migrate to the latest official aleph.im runtime automatically
+* You want your program to migrate to the latest official Aleph Cloud runtime automatically
 * You just want to upgrade your code
 * etc.
 
@@ -66,13 +66,13 @@ Let's use the `aleph` CLI to update one of our volumes.
 aleph message amend $VOLUME_REF
 ```
 
-Where `VOLUME_REF` is the `item_hash` of the STORE message that stores the file on aleph.im.
+Where `VOLUME_REF` is the `item_hash` of the STORE message that stores the file on Aleph Cloud.
 You must either own this file or have the permission to update this file 
 (see [Permissions](/devhub/building-applications/messaging/permissions)).
 
 ### Immutable volumes
 
-Similarly to programs, aleph.im also has the concept of immutable volumes.
+Similarly to programs, Aleph Cloud also has the concept of immutable volumes.
 They are volumes configured with the `use_latest` field set to false.
 These volumes will always use the version of the file configured when the program was created.
 

--- a/docs/devhub/compute-resources/functions/getting-started.md
+++ b/docs/devhub/compute-resources/functions/getting-started.md
@@ -1,9 +1,9 @@
-# Build a Python microVM
+# Getting started with functions
 
-This tutorial will guide you through the steps of building a Python microVM to run on the aleph.im network.
+This tutorial will guide you through the steps of building a Python microVM to run on the aleph cloud network.
 We will build a simple HTTP server and add features as we go.
 
-> ℹ This tutorial uses the aleph.im command line interface.
+> ℹ This tutorial uses the aleph cloud command line interface.
 
 ## Requirements
 
@@ -15,12 +15,12 @@ enough to get started.
 To complete this tutorial, you will use the `aleph` command from 
 [aleph-client](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on 
-aleph.im.
+aleph.cloud.
 
 First, you need a recent version of Python and [pip](https://pip.pypa.io/en/stable/), 
 preferably running on Debian 11 or Ubuntu 20.04.
 
-Some cryptographic functionalities of aleph.im use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+Some cryptographic functionalities of aleph.cloud use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 Archiving programs and volumes requires
 [Squashfs user space tools](https://github.com/plougher/squashfs-tools).
 
@@ -36,7 +36,7 @@ brew install libsecp256k1 squashfs
 ```
 
 You will also need [Uvicorn](https://www.uvicorn.org/) for local testing 
-and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+and the [Python aleph.cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
 
 - Linux/macOs:
 
@@ -46,13 +46,13 @@ pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
 
 ## Understanding aleph cloud programs
 
-Aleph.im programs are applications running on the aleph.im network.
+Aleph.cloud programs are applications running on the aleph.cloud network.
 Each program defines the application to be executed, data to use, computing requirements 
 (number of CPUs, amount of RAM) and many more parameters.
 
 Each program is instantiated as a __virtual machine__ running on a Compute Resource Node (CRN).
 Virtual machines are emulated computer systems with dedicated resources that run isolated from each other.
-Aleph.im Virtual Machines (VMs) are based on Linux.
+Aleph.cloud Virtual Machines (VMs) are based on Linux.
 
 We support two types of allocation: _on-demand_ and _persistent_. 
 _on-demand_ boot extremely fast and can be launched on demand. They are perfect for lightweight applications
@@ -69,14 +69,14 @@ one tenth of the $ALEPH tokens to hold, compared to a [Persistent VM](#persisten
 
 The base of each VM is a Linux 
 [root filesystem](https://en.wikipedia.org/wiki/Root_directory) named __runtime__ and configured
-to run programs on the aleph.im platform. 
+to run programs on the aleph.cloud platform. 
 
-Aleph.im provides a supported runtime to launch programs written in Python or binaries. 
+Aleph.cloud provides a supported runtime to launch programs written in Python or binaries. 
 
 - Python programs must support the [ASGI interface](https://asgi.readthedocs.io/en/latest/), described in the example below.
 - Binaries must listen for HTTP requests on port 8080
 
-You can find runtimes currently supported by aleph.im [here](/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes).
+You can find runtimes currently supported by aleph.cloud [here](/devhub/sdks-and-tools/aleph-cli/commands/program#supported-runtimes).
 
 ### Volumes
 
@@ -92,7 +92,7 @@ more memory.
 **Host persistent volumes** are persisted on the VM execution node, but may be garbage collected
 by the node without warning.
 
-**Store persistent volumes** (not available yet) are persisted on the aleph.im network. 
+**Store persistent volumes** (not available yet) are persisted on the aleph.cloud network. 
 New VMs will try to use the latest version of this volume, with no guarantee against conflicts.
 
 ## Write a Python program
@@ -125,9 +125,9 @@ Have a look at it for a better understanding of what it does and how it works.
 
 ## Test it locally
 
-Before uploading your program on aleph.im, let's test it on your machine.
+Before uploading your program on aleph.cloud, let's test it on your machine.
 
-Aleph.im uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
+Aleph.cloud uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
 interface with programs written in Python. ASGI interfaces with many Python frameworks, including
 FastAPI but also [Django](https://www.djangoproject.com/) 
 or [Quart](https://github.com/pgjones/quart).
@@ -160,7 +160,7 @@ The `--reload` option will automatically reload your app when the code changes.
 > ℹ Installing uvicorn should add the `uvicorn` command to your shell. If it does not, use
 > `python -m uvicorn` to run it.
 
-## Upload your program on aleph.im
+## Upload your program on aleph.cloud
 
 After installing [aleph-client](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
 
@@ -186,19 +186,19 @@ Ref of runtime ? [bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29
 
 You should then get a response similar to the following: 
 ```
-Your program has been uploaded on aleph.im .
+Your program has been uploaded on aleph.cloud .
 
 Available on:
   https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
 Visualise on:
-  https://explorer.aleph.im/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
 You may get the warning `Message failed to publish on IPFS and/or P2P`. 
 This is common and usually not an issue.
 
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph.im identifiers are too long to work
+> ℹ The second URL uses a hostname dedicated to your VM. Aleph.cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [advanced](/devhub/deploying-and-hosting/custom-domains/setup) section.
@@ -209,12 +209,12 @@ You can now run your program by opening one of the URLs above. Each URL is uniqu
 
 https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 
-This will automatically start your program inside a VM on the aleph.im Compute Resource Node behind
+This will automatically start your program inside a VM on the aleph.cloud Compute Resource Node behind
 the `aleph.sh` domain name and serve your request.
 
 An important thing to notice is that we did not install any specific dependency for our program,
 despite relying on FastAPI.
-This is because the official aleph.im runtime is already pre-configured with several typical Python packages.
+This is because the official aleph.cloud runtime is already pre-configured with several typical Python packages.
 Of course, you can customize your program to add your own requirements.
 Refer to [Adding Python dependencies to a program](/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes) for more information.
 

--- a/docs/devhub/compute-resources/functions/index.md
+++ b/docs/devhub/compute-resources/functions/index.md
@@ -1,6 +1,6 @@
-# Computing on Aleph.im
+# Computing on Aleph Cloud
 
-Aleph.im offers a decentralized computing framework that allows users to run
+Aleph Cloud offers a decentralized computing framework that allows users to run
 applications on the network.
 
 Two execution models are available:
@@ -41,7 +41,7 @@ On how to deploy a simple Python microVM, see our [Python microVM guide](/devhub
 
 ## Persistent Execution {#persistent-execution}
 
-When a program is created with persistent execution enabled, the aleph.im scheduler will find a Compute Resource Node
+When a program is created with persistent execution enabled, the aleph.cloud scheduler will find a Compute Resource Node
 (CRN) with enough resources to run the program and schedule the program to start on that node.
 
 Persistent programs are designed to always run exactly once, and the scheduler will reallocate the program on another
@@ -107,7 +107,7 @@ uvicorn main:app --reload
 
 ### Step 2: Run a program in a persistent manner
 
-To run the program in a persistent manner on the aleph.im network, use: 
+To run the program in a persistent manner on the aleph.cloud network, use: 
 
 ```shell
 aleph program upload --persistent ./src/ main:app

--- a/docs/devhub/deploying-and-hosting/custom-domains/setup.md
+++ b/docs/devhub/deploying-and-hosting/custom-domains/setup.md
@@ -1,10 +1,10 @@
-# Adding a Custom Domain to Your Aleph.im Instance
+# Adding a Custom Domain to Your Aleph Cloud Instance
 
-Setting up a custom domain for your decentralized instance with Aleph.im can be accomplished with just a few steps. Please carefully follow this guide to ensure a smooth process.
+Setting up a custom domain for your decentralized instance with Aleph Cloud can be accomplished with just a few steps. Please carefully follow this guide to ensure a smooth process.
 
 ## Overview
 
-Adding a custom domain to your Aleph.im instance involves:
+Adding a custom domain to your Aleph Cloud instance involves:
 
 1. Creating a CNAME record.
 2. Creating a TXT owner proof record.
@@ -22,7 +22,7 @@ Before you start, make sure you have:
 
 ## Step 1: Create a CNAME Record
 
-To add a custom domain, first, you need to create a CNAME record in your domain's DNS settings. The CNAME record will point your domain to your instance on Aleph.im.
+To add a custom domain, first, you need to create a CNAME record in your domain's DNS settings. The CNAME record will point your domain to your instance on Aleph Cloud.
 
 1. **Log into your domain provider's site.**
 2. **Navigate to your domain's DNS settings.** These settings are usually located in your domain control panel.
@@ -40,7 +40,7 @@ Save your changes before moving on to the next step.
 
 ## Step 2: Create a TXT Owner Proof Record
 
-Next, you need to create a TXT owner proof record in your domain's DNS settings. This record confirms that you own the domain associated with the Aleph.im instance.
+Next, you need to create a TXT owner proof record in your domain's DNS settings. This record confirms that you own the domain associated with the Aleph Cloud instance.
 
 1. **Still in your domain's DNS settings, create a new TXT record.**
    - For the `Name/Host/Alias` field, enter `_control.<<userdomain.com>>`.

--- a/docs/devhub/deploying-and-hosting/web-hosting/index.md
+++ b/docs/devhub/deploying-and-hosting/web-hosting/index.md
@@ -1,10 +1,10 @@
-# Web3 Hosting on Aleph.im
+# Web3 Hosting on Aleph Cloud
 
 ## Overview
 
-Aleph.im offers web3 hosting services via the [Twentysix Cloud Console](https://console.twentysix.cloud/), allowing you to deploy any kind of Dapps in few simple steps. Your websites are stored on IPFS and are fully-managed by the Aleph network.
+Aleph Cloud offers web3 hosting services via the [Aleph Cloud Console](https://app.aleph.cloud/), allowing you to deploy any kind of Dapps in few simple steps. Your websites are stored on IPFS and are fully-managed by the Aleph Cloud network.
 
-Aleph.im being GDPR-compliant, if you decide to delete your website, or some older versions of it (previous deployments), or if you stop holding the required amount of tokens to keep it online, your website will be automatically garbage collected after a grace period by our network.
+Aleph Cloud being GDPR-compliant, if you decide to delete your website, or some older versions of it (previous deployments), or if you stop holding the required amount of tokens to keep it online, your website will be automatically garbage collected after a grace period by our network.
 
 > ℹ️ IPFS being a public P2P network, your files may still be available over the network if external nodes pinned them.
 
@@ -12,7 +12,7 @@ Aleph.im being GDPR-compliant, if you decide to delete your website, or some old
 
 ### Pricing
 
-In order to host a website on Aleph.im, you need to hold a small amount of $ALEPH token in your wallet. Those tokens are not locked or staked (no transaction required), and will not be spent, they just have to sit in your wallet as a guarantee. To run a cost simulation, check out the [deployment page](https://console.twentysix.cloud/hosting/website/new/).
+In order to host a website on Aleph Cloud, you need to hold a small amount of $ALEPH token in your wallet. Those tokens are not locked or staked (no transaction required), and will not be spent, they just have to sit in your wallet as a guarantee. To run a cost simulation, check out the [deployment page](https://app.aleph.cloud/console/hosting/website/new/).
 
 ### Prepare
 
@@ -33,7 +33,7 @@ static-folder
 
 #### Framework-based Website
 
-We are listing the officially supported frameworks on TwentySix's website creation page, but you can actually use any framework (and package manager, such as npm, pnpm, yarn, bun...) to create your website.
+We are listing the officially supported frameworks on Aleph Cloud's website creation page, but you can actually use any framework (and package manager, such as npm, pnpm, yarn, bun...) to create your website.
 
 > ℹ️ Keep in mind that your website, being a decentralized frontend, must only contain client-side components, as well as the dependencies used by it. For backend support, check out the section below.
 
@@ -51,21 +51,21 @@ npm run build
 
 ### Deploy
 
-When your static folder is ready, you can deploy your website using the [Twentysix Cloud Console](https://console.twentysix.cloud/hosting/website/new/).
+When your static folder is ready, you can deploy your website using the [Aleph Cloud Console](https://app.aleph.cloud/console/hosting/website/new/).
 
-![Deploy your website](../../../assets/images/console/deploy-website.png)
+![Deploy your website](/assets/images/console/deploy-website.png)
 
 ### History and Updates
 
-You can update your website or access/redeploy previous versions easily through your [Website Management Dashboard](https://console.twentysix.cloud/hosting/website/).
+You can update your website or access/redeploy previous versions easily through your [Website Management Dashboard](https://app.aleph.cloud/console/hosting/website/).
 
-![Update website and access history](../../../assets/images/console/update-website.png)
+![Update website and access history](/assets/images/console/update-website.png)
 
 ## Access Your Dapp
 
 ### Aleph Gateway Service
 
-When your website is live on Aleph network, we provide you a gateway url to easily access it:
+When your website is live on Aleph Cloud network, we provide you a gateway url to easily access it:
 
 `https://{ipfs-cid-v1}.ipfs.aleph.sh`
 
@@ -88,7 +88,7 @@ To resolve it:
 - `Records` ➜ `Edit Records` ➜ `Other`
 - Setup `Content Hash` to: `ipfs://{ipfs-cid-v1}`
 
-![ENS record](../../../assets/images/console/ens-record.png)
+![ENS record](/assets/images/console/ens-record.png)
 
 Your website will then be accessible via:
 
@@ -127,7 +127,7 @@ In order to add a backend to your website and to make it a complete fullstack da
 
 Now that your application is fully decentralized, you want to add some AI features to it?
 
-Forget about OpenAI and other centralized providers, [LibertAI](https://libertai.io/), a decentralized & privacy-first Aleph.im-based AI project, allows you to perform inferences, manage knowledge bases, and deploy AI agents easily.
+Forget about OpenAI and other centralized providers, [LibertAI](https://libertai.io/), a decentralized & privacy-first Aleph Cloud-based AI project, allows you to perform inferences, manage knowledge bases, and deploy AI agents easily.
 
 Have a look to the [official documentation](https://docs.libertai.io/).
 

--- a/docs/devhub/examples/defi/index.md
+++ b/docs/devhub/examples/defi/index.md
@@ -828,7 +828,7 @@ const volumeData = await aleph.indexer.query(
 
 - [GitHub](https://github.com/aleph-im)
 - [Discord](https://discord.com/invite/alephcloud)
-- [Telegram](https://t.me/alephim)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your DeFi integrations, get help, and collaborate with other developers building on Aleph Cloud!

--- a/docs/devhub/examples/gaming/index.md
+++ b/docs/devhub/examples/gaming/index.md
@@ -865,7 +865,7 @@ Follow these steps to build your own gaming application with Aleph Cloud:
 
 - [GitHub](https://github.com/aleph-im)
 - [Discord](https://discord.com/invite/alephcloud)
-- [Telegram](https://t.me/alephim)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your gaming projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/docs/devhub/examples/index.md
+++ b/docs/devhub/examples/index.md
@@ -69,8 +69,8 @@ Before diving into these examples, we recommend familiarizing yourself with:
 If you have questions or need help implementing these examples, join our community:
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 We're excited to see what you build with Aleph Cloud!

--- a/docs/devhub/examples/nft/index.md
+++ b/docs/devhub/examples/nft/index.md
@@ -944,7 +944,7 @@ Follow these steps to build your own NFT application with Aleph Cloud:
 
 - [GitHub](https://github.com/aleph-im)
 - [Discord](https://discord.com/invite/alephcloud)
-- [Telegram](https://t.me/alephim)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your NFT projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/docs/devhub/examples/web3-apps/index.md
+++ b/docs/devhub/examples/web3-apps/index.md
@@ -418,7 +418,7 @@ Follow these steps to build your own web3 application with Aleph Cloud:
 
 - [GitHub](https://github.com/aleph-im)
 - [Discord](https://discord.com/invite/alephcloud)
-- [Telegram](https://t.me/alephim)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/docs/devhub/faq/index.md
+++ b/docs/devhub/faq/index.md
@@ -4,17 +4,13 @@
 
 ### Aleph
 
-- Web: [https://aleph.im](https://aleph.im)
-- Forum: [https://community.aleph.im](https://community.aleph.im)
+- Web: [https://aleph.cloud](https://aleph.cloud)
+- Forum: [https://community.aleph.cloud](https://community.aleph.cloud)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
 - Twitter: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
 - Linkedin: [https://www.linkedin.com/company/aleph-im](https://www.linkedin.com/company/aleph-im)
-- Telegram: [https://t.me/alephim](https://t.me/alephim)
+- Telegram: [https://t.me/alephcloud](https://t.me/alephcloud)
 
-### Twentysix Cloud
-
-- Web: [https://www.twentysix.cloud/](https://www.twentysix.cloud/)
-- Twitter: [https://twitter.com/twentysixcloud](https://twitter.com/twentysixcloud)
 
 ### $ALEPH Token Contracts/Mint addresses
 
@@ -24,22 +20,17 @@
 - **Solana**: [`3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x`](https://solana.fm/address/3UCMiSnkcnkPE1pgQ5ggPCBv6dXgVUy16TmMUe1WpG9x)
 - **BASE**: [`0xc0Fbc4967259786C743361a5885ef49380473dCF`](https://basescan.org/token/0xc0Fbc4967259786C743361a5885ef49380473dCF)
 
-## General Questions
-
-::: details What is Twentysix Cloud?
-Twentysix Cloud is a cross-chain cloud solution that provides scalable, high-performance resources for applications, particularly in AI, DeFi, and gaming. It is powered by the decentralized Aleph.im network. Learn more at [Twentysix Cloud](https://www.twentysix.cloud/).
-:::
 
 ## Staking
 
 ### Basics
 
 ::: details Where can I stake my $ALEPH?
-You can stake your $ALEPH at [Aleph Account](https://account.aleph.im/).
+You can stake your $ALEPH at [Aleph Account](https://app.aleph.cloud/account).
 :::
 
 ::: details Is there a staking tutorial?
-Yes, check out our [Aleph.im Staking Guide](https://medium.com/aleph-im/aleph-im-staking-guide-9b82264968be).
+Yes, check out our [Aleph Cloud Staking Guide](/about/how-to-stake).
 :::
 
 ::: details What are the staking tokenomics for stakers?
@@ -67,7 +58,7 @@ No, there is currently no cap on the amount staked on a single node.
 ### Rewards & Returns
 
 ::: details How many ALEPH will I get for staking?
-Use the calculator at the top section of the [web app](https://account.aleph.im/) to estimate your staking rewards.
+Use the calculator at the top section of the [web app](https://app.aleph.cloud/account) to estimate your staking rewards.
 :::
 
 ::: details When are the staking rewards paid?
@@ -85,7 +76,7 @@ No, the total amount staked per node does not affect individual staker rewards.
 ### Security & Flexibility
 
 ::: details Are my funds safe when I stake?
-Yes, staking on Aleph.im is non-custodial. Your tokens remain in your wallet with no lock-up period.
+Yes, staking on Aleph Cloud is non-custodial. Your tokens remain in your wallet with no lock-up period.
 :::
 
 ::: details Is there a required lock-up period to stake?
@@ -123,7 +114,7 @@ Yes, TrustWallet can be connected via WalletConnect.
 :::
 
 ::: details Can I stake with the NULS or NEO variant of the ALEPH token?
-No, you must convert NULS or NEO variants to the ERC-20 variant of ALEPH at [Aleph Swap](https://swap.aleph.im) before staking.
+No, you must convert NULS or NEO variants to the ERC-20 variant of ALEPH at [Aleph Swap](https://swap.aleph.cloud) before staking.
 :::
 
 ### Node Selection
@@ -143,7 +134,7 @@ Purchase ALEPH v2 on platforms such as Coinbase, KuCoin, Gate, LATOKEN, MEXC, Un
 :::
 
 ::: details What is Pay-As-You-Go?
-Pay-As-You-Go allows you to pay for resources as you use them on the Aleph.im network, eliminating the need to hold or stake large amounts of $ALEPH. This is currently available on BASE and Avalanche c-chain. More chains will be supported in the future, refer to the [supported chains](/about/network/supported-blockchains/) table.
+Pay-As-You-Go allows you to pay for resources as you use them on the Aleph Cloud network, eliminating the need to hold or stake large amounts of $ALEPH. This is currently available on BASE and Avalanche c-chain. More chains will be supported in the future, refer to the [supported chains](/about/network/supported-blockchains/) table.
 :::
 
 ## Node Operators

--- a/docs/devhub/getting-started/index.md
+++ b/docs/devhub/getting-started/index.md
@@ -72,11 +72,11 @@ account = client.get_account()
 
 ### 4. Try a Simple Example
 
-#### Store Data on Aleph.im
+#### Store Data on Aleph Cloud
 ::: code-group
 ```ts [TypeScript]
 // Store a simple message
-const content = { message: 'Hello, Aleph.im!' };
+const content = { message: 'Hello, Aleph Cloud!' };
 const result = await aleph.store.storeContent(
   account,
   content,
@@ -93,7 +93,7 @@ console.log(message);
 ```python [Python]
 # Store a simple message
 result = await client.create_store(
-    "Hello, Aleph.im!",
+    "Hello, Aleph Cloud!",
     tags=['example', 'hello-world']
 )
 
@@ -144,7 +144,7 @@ To help you get started, we've prepared some sample projects:
 
 1. Explore the [SDK documentation](/devhub/sdks-and-tools/typescript-sdk/) for your preferred language
 2. Check out the [API Reference](/devhub/api/rest) for detailed endpoint information
-3. Join the [Aleph.im Discord](https://discord.gg/alephim) to connect with the community
+3. Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) to connect with the community
 4. Browse [example projects](/devhub/examples/web3-apps/) for inspiration
 
 ## Getting Help
@@ -152,6 +152,6 @@ To help you get started, we've prepared some sample projects:
 If you encounter any issues or have questions:
 
 - Check the documentation for your specific use case
-- Join the [Aleph.im Discord](https://discord.gg/alephim) for community support
-- Visit the [Aleph.im GitHub](https://github.com/aleph-im) to report issues or contribute
-- Contact the Aleph.im team through the [official website](https://aleph.im/contact)
+- Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) for community support
+- Visit the [Aleph Cloud GitHub](https://github.com/aleph-im) to report issues or contribute
+- Contact the Aleph Cloud team through the [official website](https://aleph.cloud/contact)

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/account.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/account.md
@@ -1,6 +1,6 @@
 # Account Management
 
-The `account` command group helps you manage your Aleph.im identity, private keys, and account information.
+The `account` command group helps you manage your Aleph Cloud identity, private keys, and account information.
 
 ## Key Commands
 
@@ -15,7 +15,7 @@ The `account` command group helps you manage your Aleph.im identity, private key
 
 ## Creating or Importing a Key
 
-Before using most Aleph.im features, you'll need a private key:
+Before using most Aleph Cloud features, you'll need a private key:
 
 ```bash
 # Create a new Ethereum private key
@@ -55,7 +55,7 @@ aleph account show
 
 ## Chain Support
 
-Aleph.im supports multiple blockchains. Specify the chain when needed:
+Aleph Cloud supports multiple blockchains. Specify the chain when needed:
 
 ```bash
 # Create a key for a specific chain

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/file.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/file.md
@@ -1,19 +1,19 @@
 # File Operations
 
-The `file` command group allows you to upload, pin, and manage files on IPFS through the Aleph.im network.
+The `file` command group allows you to upload, pin, and manage files on IPFS through the Aleph Cloud network.
 
 ## Key Commands
 
 | Command | Description |
 |---------|-------------|
-| `upload` | Upload a file to IPFS via Aleph.im |
-| `pin` | Pin an existing IPFS file on Aleph.im |
+| `upload` | Upload a file to IPFS via Aleph Cloud |
+| `pin` | Pin an existing IPFS file on Aleph Cloud |
 | `status` | Check the status of a file |
-| `forget` | Remove a file from Aleph.im pinning |
+| `forget` | Remove a file from Aleph Cloud pinning |
 
 ## Uploading Files
 
-Upload local files to IPFS through Aleph.im:
+Upload local files to IPFS through Aleph Cloud:
 
 ```bash
 # Upload a single file
@@ -28,7 +28,7 @@ aleph file upload /path/to/file.txt --channel ALEPH-MAIN
 
 ## Pinning Existing IPFS Content
 
-If you already have content on IPFS, you can pin it on Aleph.im:
+If you already have content on IPFS, you can pin it on Aleph Cloud:
 
 ```bash
 # Pin by IPFS hash
@@ -66,7 +66,7 @@ aleph file forget QmHash123456789 --reason "No longer needed"
 
 ### Storage Engines
 
-Aleph.im supports different storage backends:
+Aleph Cloud supports different storage backends:
 
 ```bash
 # Specify storage engine
@@ -75,7 +75,7 @@ aleph file upload /path/to/file.txt --storage-engine ipfs
 
 Available storage engines:
 - `ipfs` - InterPlanetary File System
-- `storage` - Aleph.im native storage
+- `storage` - Aleph Cloud native storage
 
 ### File Metadata
 

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
@@ -1,6 +1,6 @@
 # Instance Management
 
-The `instance` command group allows you to create and manage full virtual machine instances on the Aleph.im network.
+The `instance` command group allows you to create and manage full virtual machine instances on the Aleph Cloud network.
 
 ## Key Commands
 
@@ -35,7 +35,7 @@ aleph instance create \
 
 ## Supported Operating Systems
 
-Aleph.im provides several base images:
+Aleph Cloud provides several base images:
 
 - `debian` - Debian Linux
 - `ubuntu` - Ubuntu Linux
@@ -116,7 +116,7 @@ aleph instance update INSTANCE_HASH \
 
 ## Payment Options
 
-Aleph.im offers two payment models:
+Aleph Cloud offers two payment models:
 
 ```bash
 # Create with staking payment (default)

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
@@ -1,6 +1,6 @@
 # Program Deployment
 
-The `program` command group allows you to deploy and manage serverless functions (micro-VMs) on the Aleph.im network.
+The `program` command group allows you to deploy and manage serverless functions (micro-VMs) on the Aleph Cloud network.
 
 ## Key Commands
 
@@ -34,7 +34,7 @@ aleph program create \
 
 ## Supported Runtimes
 
-Aleph.im supports multiple programming languages:
+Aleph Cloud supports multiple programming languages:
 
 - `python-3.10` - Python 3.10
 - `node-18` - Node.js 18

--- a/docs/devhub/sdks-and-tools/aleph-cli/index.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/index.md
@@ -70,7 +70,7 @@ The Aleph CLI is organized into logical command groups that correspond to differ
 | `node` | Get information about network nodes |
 | `pricing` | View pricing for Aleph Cloud services |
 
-## Getting Started
+## Getting Started {#getting-started}
 
 ### First-time Setup
 
@@ -99,7 +99,7 @@ aleph account address
 aleph account balance
 ```
 
-## Troubleshooting
+## Troubleshooting {#troubleshooting}
 
 If you encounter issues with the CLI:
 

--- a/docs/devhub/sdks-and-tools/aleph-cli/index.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/index.md
@@ -1,6 +1,6 @@
 # Aleph Cloud Command-Line Interface
 
-The Aleph Cloud CLI provides a powerful command-line interface to interact with all features of the Aleph.im network directly from your terminal.
+The Aleph Cloud CLI provides a powerful command-line interface to interact with all features of the Aleph Cloud network directly from your terminal.
 
 ## Installation
 
@@ -56,7 +56,7 @@ docker run --rm -ti \
 :::
 ## Command Overview
 
-The Aleph CLI is organized into logical command groups that correspond to different Aleph.im features:
+The Aleph CLI is organized into logical command groups that correspond to different Aleph Cloud features:
 
 | Command | Description |
 |---------|-------------|
@@ -68,7 +68,7 @@ The Aleph CLI is organized into logical command groups that correspond to differ
 | `instance` | Create and manage virtual machine instances |
 | `domain` | Configure custom domains for your deployments |
 | `node` | Get information about network nodes |
-| `pricing` | View pricing for Aleph.im services |
+| `pricing` | View pricing for Aleph Cloud services |
 
 ## Getting Started
 

--- a/docs/devhub/sdks-and-tools/index.md
+++ b/docs/devhub/sdks-and-tools/index.md
@@ -1,0 +1,32 @@
+# Aleph Cloud SDKs & CLI Overview
+
+Integrate with Aleph Cloud using our comprehensive SDKs and command-line tools. Whether you are building in Python, TypeScript, or need direct terminal access, Aleph Cloud provides robust solutions for developers.
+
+---
+
+## Available SDKs & Tools
+
+### [Python SDK](/devhub/sdks-and-tools/python-sdk/)
+The Aleph Cloud Python SDK (`aleph-sdk-python`) provides a comprehensive set of tools for interacting with the Aleph Cloud network from Python applications.
+- **Install:** `pip install aleph-sdk-python`
+
+### [TypeScript SDK](/devhub/sdks-and-tools/typescript-sdk/)
+The Aleph Cloud TypeScript SDK (`@aleph-sdk/client`) enables seamless integration with Aleph Cloud from Node.js and browser-based applications.
+- **Install:** `npm install @aleph-sdk/client`
+
+### [Aleph Cloud CLI](/devhub/sdks-and-tools/aleph-cli/)
+The Aleph Cloud Command-Line Interface (CLI) allows you to interact with all features of the Aleph Cloud network directly from your terminal.
+- **Install:** `pipx install aleph-client` (recommended)
+- [Getting Started](/devhub/sdks-and-tools/aleph-cli/index.md#getting-started)
+- [Troubleshooting](/devhub/sdks-and-tools/aleph-cli/index.md#troubleshooting)
+
+---
+
+## Why Use Aleph Cloud SDKs?
+- **Multiple Languages:** Official support for Python and TypeScript, with more on the way.
+- **Comprehensive Features:** Access storage, compute, messaging, and more.
+- **Open Source:** All SDKs and CLI are open source and maintained by the Aleph Cloud team.
+
+---
+
+For more SDKs, tools, or to contribute, visit our [GitHub organization](https://github.com/aleph-im).

--- a/docs/devhub/sdks-and-tools/python-sdk/index.md
+++ b/docs/devhub/sdks-and-tools/python-sdk/index.md
@@ -96,7 +96,7 @@ avax_account = EVMAccount(private_key=private_key, chain=Chain.AVAX) # With this
 ```python
 # Store a simple message 
 message, status = await client.create_store(
-    "Hello, Aleph.im!",
+    "Hello, Aleph Cloud!",
     extra_fields= {"tags": ["example", "hello-world"]}
 )
 
@@ -480,7 +480,7 @@ The SDK includes a command-line interface for common operations:
 
 ```bash
 # Store a message
-aleph store "Hello, Aleph.im!" --tags example,hello-world
+aleph store "Hello, Aleph Cloud!" --tags example,hello-world
 
 # Get a message
 aleph get QmHash123

--- a/docs/devhub/sdks-and-tools/typescript-sdk/index.md
+++ b/docs/devhub/sdks-and-tools/typescript-sdk/index.md
@@ -82,7 +82,7 @@ const account = aleph.ethereum.importAccount('0x1234567890abcdef1234567890abcdef
 ```javascript
 // Store a simple message
 const result = await aleph.storage.store(
-  'Hello, Aleph.im!',
+  'Hello, Aleph Cloud!',
   { tags: ['example', 'hello-world'] }
 );
 
@@ -173,7 +173,7 @@ console.log(response); // { message: 'Hello, Alice!' }
 // Deploy a VM
 const vmResult = await aleph.instance.create({
   name: 'web-server',
-  description: 'A web server running on Aleph.im',
+  description: 'A web server running on Aleph Cloud',
   cpu: 2,
   memory: 4, // GB
   disk: 20, // GB
@@ -352,7 +352,7 @@ function AlephComponent() {
   
   return (
     <div>
-      <h2>Data from Aleph.im</h2>
+      <h2>Data from Aleph Cloud</h2>
       <pre>{JSON.stringify(data, null, 2)}</pre>
     </div>
   );

--- a/docs/devhub/storage/ipfs-pinning/index.md
+++ b/docs/devhub/storage/ipfs-pinning/index.md
@@ -40,7 +40,7 @@ aleph file upload myfile.txt --pin
 
 #### Using the Web Console
 
-1. Log in to the [Aleph Cloud Web Console](https://console.aleph.im)
+1. Log in to the [Aleph Cloud Web Console](https://app.aleph.cloud)
 2. Navigate to the "Storage" section
 3. Click "Pin IPFS Content"
 4. Enter the IPFS CID you want to pin
@@ -209,8 +209,8 @@ export default async function(req, context) {
 If you encounter issues with IPFS pinning:
 
 1. Check the [Aleph Cloud documentation](/devhub/)
-2. Join the [Aleph Cloud Discord](https://discord.gg/alephim) for community support
-3. Contact support through the [Aleph Cloud website](https://aleph.im/contact)
+2. Join the [Aleph Cloud Discord](https://discord.com/invite/alephcloud) for community support
+3. Contact support through the [Aleph Cloud website](https://aleph.cloud/contact)
 
 ## Next Steps
 

--- a/docs/devhub/tools/vrf/index.md
+++ b/docs/devhub/tools/vrf/index.md
@@ -1,4 +1,4 @@
-# Aleph.im Verifiable Random Functions
+# Aleph Cloud Verifiable Random Functions
 
 From the official GitHub repository: [aleph-im/aleph-vrf](https://github.com/aleph-im/aleph-vrf)
 
@@ -9,9 +9,9 @@ and verifiable.
 This allows to create "trustless randomness", i.e. generate (pseudo-) random numbers in decentralized systems and
 provide the assurance that the number was indeed generated randomly.
 
-## Aleph.im implementation
+## Aleph Cloud implementation
 
-Aleph.im uses a combination of virtual machines (VMs) and aleph.im network messages to implement VRFs.
+Aleph Cloud uses a combination of virtual machines (VMs) and aleph cloud network messages to implement VRFs.
 
 The implementation revolves around the following components:
 
@@ -21,27 +21,27 @@ The implementation revolves around the following components:
 The coordinator receives user requests to generate random numbers.
 Upon receiving a request, it selects a set of compute resource nodes (CRNs) to act as executors.
 Each of these executors generates a random number and computes its hash using SHA3–256.
-These hashes are then posted to aleph.im using a POST message, which also includes a unique request identifier.
+These hashes are then posted to aleph cloud using a POST message, which also includes a unique request identifier.
 Once all the hashes are posted and confirmed, the coordinator requests the actual random numbers from each node.
 
 Finally, the coordinator performs a verification process to ensure that all random numbers correspond to their
 previously posted hashes. The random numbers are then combined using an XOR operation to generate the final random
-number. This final number, along with a summary of operations performed, is published on aleph.im for public
+number. This final number, along with a summary of operations performed, is published on aleph cloud for public
 verification.
 
-## How to use aleph.im VRFs
+## How to use aleph cloud VRFs
 
-The VRF executors and coordinator are meant to be deployed as VM functions on the aleph.im network.
+The VRF executors and coordinator are meant to be deployed as VM functions on the aleph cloud network.
 The coordinator can also be deployed in library mode (see below).
 
 We provide a script to deploy the VM functions.
-Just run the following command to package the application and upload it to the aleph.im network.
+Just run the following command to package the application and upload it to the aleph cloud network.
 
 ```
 python3 deployment/deploy_vrf_vms.py
 ```
 
-If the deployment succeeds, the script will display links to the VMs on the aleph.im network. Example:
+If the deployment succeeds, the script will display links to the VMs on the aleph cloud network. Example:
 
 ```
   Executor VM: https://api2.aleph.im/api/v0/messages/558b0eeea54d80d2504b0287d047e0b78458d08022d3600bcf8478700dd0aac2
@@ -75,7 +75,7 @@ from aleph_message.models import ItemHash
 
 
 async def main():
-    aleph_account = ...  # Specify your aleph.im account
+    aleph_account = ...  # Specify your aleph cloud account
     vrf_response = await generate_vrf(
         account=aleph_account,
         vrf_function=ItemHash(

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ features:
   - icon: 📚
     title: Multiple SDKs
     details: Integrate with TypeScript, Python, and other languages using our comprehensive SDKs.
-    link: /devhub/sdks-and-tools/python-sdk/
+    link: /devhub/sdks-and-tools/
     linkText: View SDKs
   - icon: 🌐
     title: Cross-Chain Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,42 +11,42 @@ hero:
       text: Get Started
       link: /devhub/getting-started/
     - theme: alt
+      text: Node Operators
+      link: /nodes/
+    - theme: alt
       text: Developer Hub
       link: /devhub/
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/aleph-cloud
 
 features:
   - icon: 💾
     title: Decentralized Storage
     details: Store data permanently and reliably on the Aleph Cloud network with IPFS integration and encryption capabilities.
-    link: /devhub/guides/storage/
+    link: /devhub/building-applications/data-storage/getting-started
     linkText: Storage Guide
   - icon: 💻
     title: Decentralized Computing
     details: Run code in a decentralized environment with on-demand functions and persistent virtual machines.
-    link: /devhub/computing/
+    link: /devhub/compute-resources/functions/getting-started
     linkText: Computing Guide
   - icon: 🗂️
     title: Blockchain Indexing
     details: Query and index blockchain data efficiently for your decentralized applications.
-    link: /devhub/guides/indexing/
+    link: /devhub/building-applications/blockchain-data/indexing/
     linkText: Indexing Guide
   - icon: 🔐
     title: Secure Authentication
     details: Implement secure authentication using blockchain wallets across multiple chains.
-    link: /devhub/guides/authentication/
+    link: /devhub/building-applications/authentication/
     linkText: Authentication Guide
   - icon: 📚
     title: Multiple SDKs
     details: Integrate with TypeScript, Python, and other languages using our comprehensive SDKs.
-    link: /devhub/sdks/typescript/
+    link: /devhub/sdks-and-tools/python-sdk/
     linkText: View SDKs
   - icon: 🌐
     title: Cross-Chain Support
     details: Build applications that work across Ethereum, Solana, Polkadot, and other blockchain ecosystems.
-    link: /devhub/
+    link: /about/network/supported-blockchains/
     linkText: Learn More
 ---
 

--- a/docs/nodes/compute/advanced/local-testing/index.md
+++ b/docs/nodes/compute/advanced/local-testing/index.md
@@ -1,6 +1,6 @@
 # Running Instances on the Local Environment
 
-Aleph.im supports two popular and high-performance hypervisors for virtualization: Firecracker and Qemu. This guide outlines the steps to run instances on your local machine for development and testing purposes.
+Aleph Cloud supports two popular and high-performance hypervisors for virtualization: Firecracker and Qemu. This guide outlines the steps to run instances on your local machine for development and testing purposes.
 
 ## 0. Prerequisites
 

--- a/docs/nodes/compute/advanced/pay-as-you-go/index.md
+++ b/docs/nodes/compute/advanced/pay-as-you-go/index.md
@@ -1,6 +1,6 @@
 # Enable PAYG (Pay-As-You-Go)
 
-Pay-As-You-Go allows user to pay for resources as you use them on the Aleph.im network, eliminating the need to hold or
+Pay-As-You-Go allows user to pay for resources as you use them on the Aleph Cloud network, eliminating the need to hold or
 stake large amounts of $ALEPH.
 
 The feature is currently available on BASE and Avalanche c-chain.
@@ -9,7 +9,7 @@ The feature is currently available on BASE and Avalanche c-chain.
 #### Configure the stream reward address
 
 1. Create an Avalanche (AVAX) or BASE wallet.
-2. Open the information of your CRN on the Aleph Cloud [account page](https://account.aleph.im/) and enter the address in
+2. Open the information of your CRN on the Aleph Cloud [account page](https://app.aleph.cloud/account) and enter the address in
    the section named STREAM REWARD ADDRESS.
 
 3. Add the reward address inside the CRN configuration `/etc/aleph-vm/supervisor.env` in the form of:

--- a/docs/nodes/compute/installation/debian-12/index.md
+++ b/docs/nodes/compute/installation/debian-12/index.md
@@ -11,7 +11,7 @@ For production using official Debian 12 packages.
 - A [supported Linux server](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator#1-supported-platforms)
 - A public domain name from a registrar and top level domain you trust.
 
-In order to run an official Aleph.im Compute Resource Node (CRN), you will also need the following resources:
+In order to run an official Aleph Cloud Compute Resource Node (CRN), you will also need the following resources:
 
 - CPU (2 options):
   - Min. 8 cores / 16 threads, 3.0 ghz+ CPU (gaming CPU for fast boot-up of microVMs)

--- a/docs/nodes/compute/installation/ubuntu-24.04/index.md
+++ b/docs/nodes/compute/installation/ubuntu-24.04/index.md
@@ -11,7 +11,7 @@ For production using official Ubuntu 24.04 LTS packages.
 - A [supported Linux server](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator#1-supported-platforms)
 - A public domain name from a registrar and top level domain you trust.
 
-In order to run an official Aleph.im Compute Resource Node (CRN), you will also need the following resources:
+In order to run an official Aleph Cloud Compute Resource Node (CRN), you will also need the following resources:
 
 - CPU (2 options):
   - Min. 8 cores / 16 threads, 3.0 ghz+ CPU (gaming CPU for fast boot-up of microVMs)

--- a/docs/nodes/compute/introduction/index.md
+++ b/docs/nodes/compute/introduction/index.md
@@ -95,4 +95,4 @@ If you're interested in running a Compute Resource Node:
 1. Follow the [Installation Guide](/nodes/compute/installation/ubuntu-24.04/) to set up your node
 2. Learn about [Advanced Features](/nodes/compute/advanced/confidential/) such as confidential computing
 
-Running a Compute Resource Node is a significant contribution to the Aleph.im ecosystem and helps provide the computing power needed for decentralized applications.
+Running a Compute Resource Node is a significant contribution to the Aleph Cloud ecosystem and helps provide the computing power needed for decentralized applications.

--- a/docs/nodes/core/installation/index.md
+++ b/docs/nodes/core/installation/index.md
@@ -121,7 +121,7 @@ docker-compose logs
 
 ## Node Registration
 
-To receive rewards, you need to register your node on the Aleph.im network:
+To receive rewards, you need to register your node on the Aleph Cloud network:
 
 1. Retrieve your node's multiaddress by running the following command (replace NODE_IP_ADDRESS with your node's public IP):
 
@@ -129,7 +129,7 @@ To receive rewards, you need to register your node on the Aleph.im network:
    curl -s http://NODE_IP_ADDRESS:4024/api/v0/info/public.json | jq -r .node_multi_addresses[0]
    ```
 
-2. Visit the [Node Operator Dashboard](https://account.aleph.im/earn/ccn/)
+2. Visit the [Node Operator Dashboard](https://app.aleph.cloud/account/earn/ccn/)
 3. Connect your wallet containing ALEPH tokens
 4. Follow the registration process, providing your node's multiaddress
 5. Stake the required amount of ALEPH tokens _(200,000 ALEPH)_

--- a/docs/nodes/core/introduction/index.md
+++ b/docs/nodes/core/introduction/index.md
@@ -26,13 +26,13 @@ CCNs are designed to be highly scalable and fault-tolerant, ensuring that the Al
 
 ## Node Operators
 
-Aleph.im Core Channel Nodes are operated by a diverse set of participants, including individuals, organizations, and developers, which helps ensure the decentralization and security of the network. 
+Aleph Cloud Core Channel Nodes are operated by a diverse set of participants, including individuals, organizations, and developers, which helps ensure the decentralization and security of the network. 
 
 To become a Core Channel Node operator, participants must stake 200,000 ALEPH tokens. This stake acts as collateral, ensuring node operators remain trustworthy and provide dependable services. It's important to note that these tokens are stored non-custodially, meaning operators retain full control over their funds without any tokens being locked. If these tokens are removed from the wallet, the node will automatically be deactivated, and all community stakers will be removed from the node.
 
 Additionally, for a node to activate on the network, it must have a total stake of 500,000 ALEPH tokens, contributed collectively by community stakers. Node operators receive rewards in ALEPH tokens for their network contributions, incentivizing continued high-quality service.
 
-For the latest APY information and detailed staking instructions, visit the [Aleph Account page](https://account.aleph.im/earn/ccn/).
+For the latest APY information and detailed staking instructions, visit the [Aleph Cloud Account page](https://app.aleph.cloud/account/earn/ccn/).
 
 ## Hardware Requirements {#hardware-requirements}
 
@@ -50,4 +50,4 @@ If you're interested in running a Core Channel Node:
 1. Follow the [Installation Guide](/nodes/core/installation/) to set up your node
 2. Learn about [Node Backups](/nodes/resources/management/backups/) to ensure your data is safe
 
-Running a Core Channel Node is a significant contribution to the Aleph.im ecosystem and helps maintain the decentralized nature of the network.
+Running a Core Channel Node is a significant contribution to the Aleph Cloud ecosystem and helps maintain the decentralized nature of the network.

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -37,4 +37,4 @@ Compute Resource Nodes (CRNs) provide the computational power for the network. T
 
 Node operators are rewarded for their contributions to the network. The reward structure varies by node type and is designed to incentivize reliable operation and network growth.
 
-For more information about the economic model and rewards, please visit the [Aleph.im website](https://aleph.im/infrastructure/).
+For more information about the economic model and rewards, please visit the [Aleph Cloud website](https://aleph.cloud/infrastructure/).

--- a/docs/nodes/resources/management/backups/index.md
+++ b/docs/nodes/resources/management/backups/index.md
@@ -1,6 +1,6 @@
 # How to backup a CCN
 
-The data stored by aleph.im Core Channel Nodes (CCN) is redundant and can be retrieved from the network in case of
+The data stored by aleph cloud Core Channel Nodes (CCN) is redundant and can be retrieved from the network in case of
 emergencies. However, there are a few important factors to consider in order to minimize node downtime, safeguard
 reputation, and maximize rewards.
 

--- a/docs/nodes/resources/management/monitoring/index.md
+++ b/docs/nodes/resources/management/monitoring/index.md
@@ -50,9 +50,9 @@ Again, this list is not exhaustive, and there are many other resource monitoring
 ## Node metrics
 
 Measurements of the performance and reliability of the nodes are published in the form of 
-[POST messages](/devhub/building-applications/messaging/object-types/posts) to the Aleph.im network. See the [metrics](/nodes/resources/metrics/) page for more information.
+[POST messages](/devhub/building-applications/messaging/object-types/posts) to the Aleph Cloud network. See the [metrics](/nodes/resources/metrics/) page for more information.
 
-You can find [the metrics and scoring messages on the Explorer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&page=1&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
+You can find [the metrics and scoring messages on the Explorer](https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&page=1&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
 
 The last two weeks of metrics of a specific node can be fetched from any Core Channel Node (CCN) by using the following
 endpoint: 

--- a/docs/nodes/resources/management/troubleshooting/index.md
+++ b/docs/nodes/resources/management/troubleshooting/index.md
@@ -9,7 +9,7 @@ A well performing node must be up-to-date. This includes:
 - Running the latest version of the node software.
 - All system updates installed.
 
-New versions of the node software are announced on the [Node operators Telegram Channel](https://t.me/alephim/123724)
+New versions of the node software are announced on the [Node operators Telegram Channel](https://t.me/alephcloud/123724)
 as well as on the GitHub repositories:
 
 - [https://github.com/aleph-im/pyaleph/releases](https://github.com/aleph-im/pyaleph/releases) for Core Channel Nodes
@@ -37,7 +37,7 @@ Setting up a Compute Resource Node can be a daunting task. This page is here to 
 - Ensure to backup configuration files before making changes.
 - Monitor the node after each troubleshooting step to check for resolution.
 - Document each step taken for future reference or for support if needed.
-- If you are unable to resolve the issue, then please check out the latest issues on the [Discourse Forum](https://community.aleph.im/c/node-operators/7) for support.
+- If you are unable to resolve the issue, then please check out the latest issues on the [Discourse Forum](https://community.aleph.cloud/c/node-operators/7) for support.
 
 ## 1) 404: Invalid message reference
 
@@ -118,7 +118,7 @@ The runtime of the new diagnostic VM appears to be improperly downloaded or corr
 ### Issue Summary
 
 The `diagnostic_vm_latency` metrics data is missing for your CRN, even though virtualization is reportedly operational.
-Users can check the raw network metrics data for their node on the [Message Explorer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&type=POST&page=1).
+Users can check the raw network metrics data for their node on the [Message Explorer](https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&type=POST&page=1).
 For more info on the data found there, see [Metrics](/nodes/resources/metrics/).
 
 Two urls are used to check this marker:

--- a/docs/nodes/resources/metrics/index.md
+++ b/docs/nodes/resources/metrics/index.md
@@ -2,7 +2,7 @@
 
 Metrics are measurements of the performance and reliability of the nodes.
 
-A program measures every hour the status and performance of the nodes, and publishes this data messages on the aleph.im network.
+A program measures every hour the status and performance of the nodes, and publishes this data messages on the Aleph Cloud network.
 This program sends multiple HTTP requests to each node in order to evaluate how well it behaves.
 
 The measurement program is part of the open-source [aleph-scoring](https://github.com/aleph-im/aleph-scoring/) project. All source code
@@ -30,7 +30,7 @@ At the end of the hour, the program publishes the results in JSON in the form of
 
 Production metrics are signed by the address `0x4D52380D3191274a04846c89c069E6C3F2Ed94e4`.
 
-> 🔗 See [the metrics messages on the exporer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&page=1&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4)
+> 🔗 See [the metrics messages on the exporer](https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&page=1&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4)
 
 ## Common metrics
 
@@ -120,9 +120,9 @@ Metrics messages can be found:
 
 ### On the Message Explorer
 
-Browser the metrics messages on the [Aleph.im Explorer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
+Browser the metrics messages on the [Aleph Cloud Explorer](https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
 
-[https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4)
+[https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4](https://explorer.aleph.cloud/messages?showAdvancedFilters=1&channels=aleph-scoring&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4)
 
 ![Node metrics explorer](/assets/images/management/metrics/metrics-explorer.png)
 

--- a/docs/nodes/resources/releases/index.md
+++ b/docs/nodes/resources/releases/index.md
@@ -3,9 +3,9 @@
 ## Compute Resource Node (CRN)
 
 The _aleph-vm_ software orchestrates the execution of virtual machines on
-[aleph.im compute resource nodes](/nodes/compute/introduction/) using two hypervisors: 
+[aleph cloud compute resource nodes](/nodes/compute/introduction/) using two hypervisors: 
 _QEMU_ and _Firecracker_. 
-This software is collaboratively developed by _aleph.im_ and the open-source community, 
+This software is collaboratively developed by _aleph cloud_ and the open-source community, 
 with the main repository located at [aleph-im/aleph-vm on GitHub](https://github.com/aleph-im/aleph-vm).
 
 ### Versioning
@@ -24,7 +24,7 @@ Additional labels for pre-release follow [Python's PEP-0440](https://www.python.
 
 Development is primarily conducted through Pull Requests (PRs) and code reviews targeting the `main` branch.
 
-Commits must follow the commit style [defined on the community forum](https://community.aleph.im/t/git-commit-style/110).
+Commits must follow the commit style [defined on the community forum](https://community.aleph.cloud/t/git-commit-style/110).
 
 Significant updates trigger preparation for a new release.
 
@@ -43,6 +43,6 @@ _aleph-vm_ is published in two formats:
 4. Draft release notes are prepared on the GitHub releases page.
 5. Packages are downloaded, unpacked, and attached to the release.
 6. Release notes are reviewed and published.
-7. The release is announced on [Twitter](https://twitter.com/aleph_im), [Telegram](https://t.me/alephim), and other channels.
+7. The release is announced on [Twitter](https://twitter.com/aleph_im), [Telegram](https://t.me/alephcloud), and other channels.
 
 All releases are documented on the [_aleph-vm_ GitHub releases page](https://github.com/aleph-im/aleph-vm/releases).

--- a/docs/nodes/resources/rewards/index.md
+++ b/docs/nodes/resources/rewards/index.md
@@ -1,11 +1,11 @@
 # Rewards
 
-Node operators and stakers receive rewards for contributing to the aleph.im network and its ecosystem.
+Node operators and stakers receive rewards for contributing to the aleph cloud network and its ecosystem.
 
 ## Core Channel Nodes
 
-A [Core Channel Node](/nodes/core/introduction/) (CCN) is active when it is registered on the [aleph.im account page](
-https://account.aleph.im), has enough ALEPH token staked on it and has a [score](/nodes/resources/scoring/) non null.
+A [Core Channel Node](/nodes/core/introduction/) (CCN) is active when it is registered on the [aleph.cloud account page](
+https://app.aleph.cloud/account), has enough ALEPH token staked on it and has a [score](/nodes/resources/scoring/) non null.
 
 The performance score of a CCN affects the rewards distributed to the operator and stakers of the node the following way:
 

--- a/docs/nodes/resources/scoring/index.md
+++ b/docs/nodes/resources/scoring/index.md
@@ -17,7 +17,7 @@ The score is computed daily and is based on all past [metrics](/nodes/resources/
 A new node starts with a score of `0%` and is expected to reach a score above `80%` after two or three weeks of operation
 when performing well. The score is based on the last two years of metrics, with recent metrics having a higher weight.
 
-![Illustration of the score if an ideal node over time (hours)](./assets/scoring-ideal-over-time.png)
+![Illustration of the score if an ideal node over time (hours)](/assets/scoring-ideal-over-time.png)
 
 Percentiles are used when processing numeric metrics to ensure that the score is not affected by outliers.
 
@@ -30,7 +30,7 @@ for a long time.
 ## Methodology
 
 The score is computed using an SQL query on the metrics. The query can be run on the database of any
-[Core Channel Node](/nodes/core/introduction/) (CCN). A Core Channel Node operated by aleph.im regularly 
+[Core Channel Node](/nodes/core/introduction/) (CCN). A Core Channel Node operated by aleph cloud regularly 
 [publishes](#publishing) the scores.
 
 ## How the score is computed
@@ -55,7 +55,7 @@ Here, $p1$ is adjusted to emphasize recent metrics, while $p2$ is tuned to favou
 
 Meanwhile, $m1$ and $m2$ serve as proportional multipliers to ensure the total remains within the range $[0..1]$.
     
-![Scoring Multiplier](./assets/scoring-multiplier.png)
+![Scoring Multiplier](/assets/scoring-multiplier.png)
 
 2. For every hour, a partial score based on the metrics measured that hour. When multiple metrics are present, the 67th percentile is used (the worst third is ignored). The partial scores are multipled together and fractional exponents remove the bias from the multiplication. When the version of the software running that hour was invalid, the partial score is set to zero.
 
@@ -69,7 +69,7 @@ The $tuning$ a number tuned such that most nodes have a score between `80%` and 
 <br/>
 ## Publishing
 
-Scores are published as a POST message on aleph.im, with the type `aleph-scoring-scores`.
+Scores are published as a POST message on aleph.cloud, with the type `aleph-scoring-scores`.
 
-You can [find the scores on the aleph.im Explorer](
-https://explorer.aleph.im/address/ETH/0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
+You can [find the scores on the aleph.cloud Explorer](
+https://explorer.aleph.cloud/address/ETH/0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).

--- a/docs/nodes/staking/index.md
+++ b/docs/nodes/staking/index.md
@@ -25,7 +25,7 @@ Follow these step-by-step instructions to begin staking your Aleph tokens:
 ### 1. Prerequisites
 - **Minimum Tokens:** Ensure you have at least **10,000 Aleph tokens**.
 - **Supported Wallet:** Use a wallet that supports Ethereum ALEPH tokens.
-- **Staking Platform:** Access the Aleph Cloud staking platform on the [account page](https://account.aleph.im).
+- **Staking Platform:** Access the Aleph Cloud staking platform on the [account page](https://app.aleph.cloud/account).
 
 ### 2. Select a Core Channel Node (CCN)
 - **Browse Available CCNs:** Navigate to the "Staking" section on the platform. Here, CCNs that have not yet reached the activation threshold (500,000 ALEPH) are listed at the top, followed by those that are already active.
@@ -50,4 +50,4 @@ Follow these step-by-step instructions to begin staking your Aleph tokens:
 
 Staking with Aleph Cloud is more than just earning rewards—it's about actively participating in a decentralized ecosystem where you help govern the network. With auto-compounded rewards, flexible CCN selection, and a secure, **noncustodial process**, staking is an excellent way to grow your stake and support the future of a decentralized cloud.
 
-Join us today at [account.aleph.im](https://account.aleph.im) and help shape the future of the Aleph Cloud network!
+Join us today at [Aleph Cloud](https://app.aleph.cloud/account) and help shape the future of the Aleph Cloud network!

--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "v1.0.0-bd48334",
+  "version": "v1.0.0-36ec558",
   "isLocal": true,
   "localUrl": "http://localhost:5173",
-  "buildTime": "2025-04-30T12:06:46.754Z"
+  "buildTime": "2025-05-02T12:07:02.286Z"
 }

--- a/docs/tools/test-components.md
+++ b/docs/tools/test-components.md
@@ -7,7 +7,7 @@ hero:
   tagline: Explore the power and flexibility of VitePress
   image:
     src: https://cdn.builder.io/api/v1/image/assets%2F5729da240c404db0a5adeed7b8d8ae9f%2Ff9254782244c4e3180d5c7d5feb890fd
-    alt: Aleph.im
+    alt: Aleph Cloud
   actions:
     - theme: brand
       text: Get Started
@@ -185,7 +185,7 @@ This info box has a custom title.
 
 ## Images with Captions
 
-![Aleph.im Logo](https://cdn.builder.io/api/v1/image/assets%2F5729da240c404db0a5adeed7b8d8ae9f%2Ff9254782244c4e3180d5c7d5feb890fd)
+![Aleph Cloud Logo](https://cdn.builder.io/api/v1/image/assets%2F5729da240c404db0a5adeed7b8d8ae9f%2Ff9254782244c4e3180d5c7d5feb890fd)
 *This is an image caption*
 
 ## Diagrams with Mermaid (if enabled in config)

--- a/tmp-backup/computing/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
+++ b/tmp-backup/computing/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
@@ -2,7 +2,7 @@
 
 Many Python programs require additional packages beyond those present on the system by default.
 While you could of course create your own runtime, there is a faster and easier solution.
-The official aleph.im Python runtimes automatically includes `/opt/packages` in the Python search path (`PYTHONPATH`). Mounting a volume on this path will make any Python module or package present in that volume importable from your program.
+The official aleph cloud Python runtimes automatically includes `/opt/packages` in the Python search path (`PYTHONPATH`). Mounting a volume on this path will make any Python module or package present in that volume importable from your program.
 
 Using a dedicated volume for your dependencies has several advantages:
 
@@ -47,8 +47,8 @@ mksquashfs ./my-packages packages.squashfs
 
 ## Upload the dependency volume
 
-To use this volume inside a program, we need the aleph.im message hash storing
-this volume, meaning that we need to upload the volume to aleph.im first.
+To use this volume inside a program, we need the aleph cloud message hash storing
+this volume, meaning that we need to upload the volume to aleph cloud first.
 
 ### Without IPFS (small size)
 
@@ -95,7 +95,7 @@ Finally, press Enter to skip adding more volumes.
 Add volume ? [y/N]
 ```
 
-Your program should be uploaded on aleph.im.
+Your program should be uploaded on aleph cloud.
 
 ## [macOS] Set up your environment with Vagrant
 

--- a/tmp-backup/computing/functions/advanced/custom-builds/python/advanced/features.md
+++ b/tmp-backup/computing/functions/advanced/custom-builds/python/advanced/features.md
@@ -1,6 +1,6 @@
 # Advanced Python program features
 
-## Aleph.im messages
+## Aleph Cloud messages
 
 The [aleph-sdk-python](https://github.com/aleph-im/aleph-sdk-python) library is pre-installed and 
 pre-configured in the official Aleph-VM Python runtime. It is tweaked to work even
@@ -8,7 +8,7 @@ for programs with the access to internet disabled.
 
 ### Get messages
 
-Use `aleph.sdk.client.AlephHttpClient` to get messages from the aleph.im network.
+Use `aleph.sdk.client.AlephHttpClient` to get messages from the aleph cloud network.
 
 ```python
 from aleph.sdk.client import AlephHttpClient
@@ -24,11 +24,11 @@ async def get_messages():
         return resp.messages
 ```
 
-## Post Aleph.im messages
+## Post Aleph Cloud messages
 
-Messages posted by VMs may not be authorized by the aleph.im network yet.
+Messages posted by VMs may not be authorized by the aleph cloud network yet.
 
-Posting messages on the aleph.im network requires signing them using a valid account.
+Posting messages on the aleph cloud network requires signing them using a valid account.
 Since programs are public, they should not contain secrets. Instead of signing messages
 themselves, programs should therefore ask their execution host to sign messages on their behalf
 using a `RemoteAccount`. The hash of the VM will be referenced in the message content `address` 
@@ -67,7 +67,7 @@ be useful to persist between executions but can be recovered from other sources.
 The cache is specific to one program on one execution node.
 
 The persistence of the cache should not be relied on - its content can be deleted anytime when
-the program is not running. Important data must be persisted on the aleph.im network. 
+the program is not running. Important data must be persisted on the aleph cloud network. 
 
 To use the cache, you can use the following methods:
 ```python
@@ -88,7 +88,7 @@ started.
 
 ### Immutable volumes
 
-Immutable volumes contain extra files that can be used by a program and are stored on the aleph.im 
+Immutable volumes contain extra files that can be used by a program and are stored on the aleph cloud 
 network. They can be shared by multiple programs and updated independently of the code of the program.
 
 You can use them to store Python libraries that your program depends on, use them in multiple
@@ -115,7 +115,7 @@ ipfs add extra-lib.squashfs
 ```
 and retrieve the printed IPFS hash.
 
-Pin the volume on aleph.im using `aleph pin`:
+Pin the volume on aleph cloud using `aleph pin`:
 ```shell
 aleph pin $IPFS_HASH --channel TEST
 ```
@@ -140,7 +140,7 @@ Like the cache, host persistent volumes are specific to one program on one execu
 Unlike the cache, you can use these volumes to store any kind of files, including databases.
 
 There is no guarantee that these volumes will not be deleted anytime when the
-program is not running and important data must be persisted on the aleph.im network.
+program is not running and important data must be persisted on the aleph cloud network.
 
 Host persistent volumes have a fixed size and must be named. The name will be used in the future
 to allow changing the mount point of a volume.

--- a/tmp-backup/computing/functions/advanced/custom-builds/python/getting-started/index.md
+++ b/tmp-backup/computing/functions/advanced/custom-builds/python/getting-started/index.md
@@ -1,9 +1,9 @@
 # Build a Python microVM
 
-This tutorial will guide you through the steps of building a Python microVM to run on the aleph.im network.
+This tutorial will guide you through the steps of building a Python microVM to run on the aleph cloud network.
 We will build a simple HTTP server and add features as we go.
 
-> ℹ This tutorial uses the aleph.im command line interface.
+> ℹ This tutorial uses the aleph cloud command line interface.
 
 ## Requirements
 
@@ -15,12 +15,12 @@ enough to get started.
 To complete this tutorial, you will use the `aleph` command from 
 [aleph-client](../../tools/aleph-client/index.md), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on 
-aleph.im.
+aleph cloud.
 
 First, you need a recent version of Python and [pip](https://pip.pypa.io/en/stable/), 
 preferably running on Debian 11 or Ubuntu 20.04.
 
-Some cryptographic functionalities of aleph.im use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+Some cryptographic functionalities of aleph cloud use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 Archiving programs and volumes requires
 [Squashfs user space tools](https://github.com/plougher/squashfs-tools).
 
@@ -36,7 +36,7 @@ brew install libsecp256k1 squashfs
 ```
 
 You will also need [Uvicorn](https://www.uvicorn.org/) for local testing 
-and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+and the [Python aleph cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
 
 - Linux/macOs:
 
@@ -44,15 +44,15 @@ and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for i
 pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
 ```
 
-## Understanding aleph.im programs
+## Understanding aleph cloud programs
 
-Aleph.im programs are applications running on the aleph.im network.
+Aleph cloud programs are applications running on the aleph cloud network.
 Each program defines the application to be executed, data to use, computing requirements 
 (number of CPUs, amount of RAM) and many more parameters.
 
 Each program is instantiated as a __virtual machine__ running on a Compute Resource Node (CRN).
 Virtual machines are emulated computer systems with dedicated resources that run isolated from each other.
-Aleph.im Virtual Machines (VMs) are based on Linux.
+Aleph cloud Virtual Machines (VMs) are based on Linux.
 
 We support two types of allocation: _on-demand_ and _persistent_. 
 _on-demand_ boot extremely fast and can be launched on demand. They are perfect for lightweight applications
@@ -69,14 +69,14 @@ one tenth of the $ALEPH tokens to hold, compared to a [Persistent VM](#persisten
 
 The base of each VM is a Linux 
 [root filesystem](https://en.wikipedia.org/wiki/Root_directory) named __runtime__ and configured
-to run programs on the aleph.im platform. 
+to run programs on the aleph cloud platform. 
 
-Aleph.im provides a supported runtime to launch programs written in Python or binaries. 
+Aleph cloud provides a supported runtime to launch programs written in Python or binaries. 
 
 - Python programs must support the [ASGI interface](https://asgi.readthedocs.io/en/latest/), described in the example below.
 - Binaries must listen for HTTP requests on port 8080
 
-You can find runtimes currently supported by aleph.im [here](../../computing/runtimes/index.md#existing-runtimes).
+You can find runtimes currently supported by aleph cloud [here](../../computing/runtimes/index.md#existing-runtimes).
 
 ### Volumes
 
@@ -92,7 +92,7 @@ more memory.
 **Host persistent volumes** are persisted on the VM execution node, but may be garbage collected
 by the node without warning.
 
-**Store persistent volumes** (not available yet) are persisted on the aleph.im network. 
+**Store persistent volumes** (not available yet) are persisted on the aleph cloud network. 
 New VMs will try to use the latest version of this volume, with no guarantee against conflicts.
 
 ## Write a Python program
@@ -125,9 +125,9 @@ Have a look at it for a better understanding of what it does and how it works.
 
 ## Test it locally
 
-Before uploading your program on aleph.im, let's test it on your machine.
+Before uploading your program on aleph cloud, let's test it on your machine.
 
-Aleph.im uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
+Aleph cloud uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
 interface with programs written in Python. ASGI interfaces with many Python frameworks, including
 FastAPI but also [Django](https://www.djangoproject.com/) 
 or [Quart](https://github.com/pgjones/quart).
@@ -160,7 +160,7 @@ The `--reload` option will automatically reload your app when the code changes.
 > ℹ Installing uvicorn should add the `uvicorn` command to your shell. If it does not, use
 > `python -m uvicorn` to run it.
 
-## Upload your program on aleph.im
+## Upload your program on aleph cloud
 
 After installing [aleph-client](../../tools/aleph-client/index.md), you should have access to the `aleph` command:
 
@@ -186,19 +186,19 @@ Ref of runtime ? [bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29
 
 You should then get a response similar to the following: 
 ```
-Your program has been uploaded on aleph.im .
+Your program has been uploaded on aleph cloud .
 
 Available on:
   https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
 Visualise on:
-  https://explorer.aleph.im/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
 You may get the warning `Message failed to publish on IPFS and/or P2P`. 
 This is common and usually not an issue.
 
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph.im identifiers are too long to work
+> ℹ The second URL uses a hostname dedicated to your VM. Aleph cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [advanced](./advanced.md) section.
@@ -209,12 +209,12 @@ You can now run your program by opening one of the URLs above. Each URL is uniqu
 
 https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 
-This will automatically start your program inside a VM on the aleph.im Compute Resource Node behind
+This will automatically start your program inside a VM on the aleph cloud Compute Resource Node behind
 the `aleph.sh` domain name and serve your request.
 
 An important thing to notice is that we did not install any specific dependency for our program,
 despite relying on FastAPI.
-This is because the official aleph.im runtime is already pre-configured with several typical Python packages.
+This is because the official aleph cloud runtime is already pre-configured with several typical Python packages.
 Of course, you can customize your program to add your own requirements.
 Refer to [Adding Python dependencies to a program](./dependency_volume.md) for more information.
 

--- a/tmp-backup/computing/functions/advanced/custom-builds/rust.md
+++ b/tmp-backup/computing/functions/advanced/custom-builds/rust.md
@@ -2,14 +2,14 @@
 
 > This tutorial follows up the first tutorial [Creating and hosting a Python program on Aleph-VM](/devhub/computing/functions/getting-started/).
 
-In this tutorial, we will build and deploy a Rust application on the aleph.im network.
+In this tutorial, we will build and deploy a Rust application on the aleph cloud network.
 
 In addition to running Python programs using ASGI as covered in the first tutorial, 
-Aleph.im VMs also support any program as long as it listens for HTTP requests on port 8080.
+aleph cloud VMs also support any program as long as it listens for HTTP requests on port 8080.
 
 ## The application
 
-In this first section, you will run a program written in Rust on an aleph.im VM.
+In this first section, you will run a program written in Rust on an aleph cloud VM.
 
 ### Requirements
 
@@ -74,7 +74,7 @@ cargo run
 
 Open `http://127.0.0.1:8080` in your browser to test your new server.
 
-## Upload your program on aleph.im
+## Upload your program on aleph cloud
 
 Let's upload our program.
 

--- a/tmp-backup/computing/functions/advanced/test-programs.md
+++ b/tmp-backup/computing/functions/advanced/test-programs.md
@@ -1,6 +1,6 @@
 # How to test your Function (Program) locally
 
-You can test your Function locally without uploading each version on the aleph.im network.
+You can test your Function locally without uploading each version on the aleph cloud network.
 
 To do this, you'll want to use the `--fake-data-program` or `-f` argument of the VM Supervisor.
 
@@ -55,7 +55,7 @@ python -m vm_supervisor --print-settings --very-verbose --system-logs --fake-dat
 
 ### 2.a. Install the system requirements
 
-Refer to [the aleph.im VM supervisor documentation](https://github.com/aleph-im/aleph-vm/blob/main/vm_supervisor/README.md) to install the system requirements.
+Refer to [the aleph cloud VM supervisor documentation](https://github.com/aleph-im/aleph-vm/blob/main/vm_supervisor/README.md) to install the system requirements.
 
 ### 2.b. Run the supervisor with fake data:
 

--- a/tmp-backup/computing/functions/advanced/update-programs.md
+++ b/tmp-backup/computing/functions/advanced/update-programs.md
@@ -3,7 +3,7 @@
 Whether it is to add new features to your application, upgrade to the latest version of a dependency or migrate to
 a new runtime, there are numerous reasons why you will update your program.
 
-In this tutorial, we will see how you can, and sometimes cannot, update programs deployed on the aleph.im network.
+In this tutorial, we will see how you can, and sometimes cannot, update programs deployed on the aleph cloud network.
 
 There are two main solutions to update a program:\
 1. Update the program directly\
@@ -54,7 +54,7 @@ of its volumes.
 There are numerous cases where this is the best option:
 
 * You detected a security vulnerability in one of your dependencies and want to migrate to a fixed version
-* You want your program to migrate to the latest official aleph.im runtime automatically
+* You want your program to migrate to the latest official aleph cloud runtime automatically
 * You just want to upgrade your code
 * etc.
 
@@ -66,13 +66,13 @@ Let's use the `aleph` CLI to update one of our volumes.
 aleph message amend $VOLUME_REF
 ```
 
-Where `VOLUME_REF` is the `item_hash` of the STORE message that stores the file on aleph.im.
+Where `VOLUME_REF` is the `item_hash` of the STORE message that stores the file on aleph cloud.
 You must either own this file or have the permission to update this file 
 (see [Permissions](../protocol/permissions.md)).
 
 ### Immutable volumes
 
-Similarly to programs, aleph.im also has the concept of immutable volumes.
+Similarly to programs, aleph cloud also has the concept of immutable volumes.
 They are volumes configured with the `use_latest` field set to false.
 These volumes will always use the version of the file configured when the program was created.
 

--- a/tmp-backup/computing/functions/getting-started.md
+++ b/tmp-backup/computing/functions/getting-started.md
@@ -1,9 +1,9 @@
 # Build a Python microVM
 
-This tutorial will guide you through the steps of building a Python microVM to run on the aleph.im network.
+This tutorial will guide you through the steps of building a Python microVM to run on the aleph cloud network.
 We will build a simple HTTP server and add features as we go.
 
-> ℹ This tutorial uses the aleph.im command line interface.
+> ℹ This tutorial uses the aleph cloud command line interface.
 
 ## Requirements
 
@@ -15,12 +15,12 @@ enough to get started.
 To complete this tutorial, you will use the `aleph` command from 
 [aleph-client](../../tools/aleph-client/index.md), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on 
-aleph.im.
+aleph cloud.
 
 First, you need a recent version of Python and [pip](https://pip.pypa.io/en/stable/), 
 preferably running on Debian 11 or Ubuntu 20.04.
 
-Some cryptographic functionalities of aleph.im use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+Some cryptographic functionalities of aleph cloud use curve secp256k1 and require installing [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 Archiving programs and volumes requires
 [Squashfs user space tools](https://github.com/plougher/squashfs-tools).
 
@@ -36,7 +36,7 @@ brew install libsecp256k1 squashfs
 ```
 
 You will also need [Uvicorn](https://www.uvicorn.org/) for local testing 
-and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+and the [Python aleph cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
 
 - Linux/macOs:
 
@@ -44,15 +44,15 @@ and the [Python aleph.im client](https://github.com/aleph-im/aleph-client) for i
 pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
 ```
 
-## Understanding aleph.im programs
+## Understanding aleph cloud programs
 
-Aleph.im programs are applications running on the aleph.im network.
+Aleph cloud programs are applications running on the aleph cloud network.
 Each program defines the application to be executed, data to use, computing requirements 
 (number of CPUs, amount of RAM) and many more parameters.
 
 Each program is instantiated as a __virtual machine__ running on a Compute Resource Node (CRN).
 Virtual machines are emulated computer systems with dedicated resources that run isolated from each other.
-Aleph.im Virtual Machines (VMs) are based on Linux.
+Aleph cloud Virtual Machines (VMs) are based on Linux.
 
 We support two types of allocation: _on-demand_ and _persistent_. 
 _on-demand_ boot extremely fast and can be launched on demand. They are perfect for lightweight applications
@@ -69,14 +69,14 @@ one tenth of the $ALEPH tokens to hold, compared to a [Persistent VM](#persisten
 
 The base of each VM is a Linux 
 [root filesystem](https://en.wikipedia.org/wiki/Root_directory) named __runtime__ and configured
-to run programs on the aleph.im platform. 
+to run programs on the aleph cloud platform. 
 
-Aleph.im provides a supported runtime to launch programs written in Python or binaries. 
+Aleph cloud provides a supported runtime to launch programs written in Python or binaries. 
 
 - Python programs must support the [ASGI interface](https://asgi.readthedocs.io/en/latest/), described in the example below.
 - Binaries must listen for HTTP requests on port 8080
 
-You can find runtimes currently supported by aleph.im [here](../../computing/runtimes/index.md#existing-runtimes).
+You can find runtimes currently supported by aleph cloud [here](../../computing/runtimes/index.md#existing-runtimes).
 
 ### Volumes
 
@@ -92,7 +92,7 @@ more memory.
 **Host persistent volumes** are persisted on the VM execution node, but may be garbage collected
 by the node without warning.
 
-**Store persistent volumes** (not available yet) are persisted on the aleph.im network. 
+**Store persistent volumes** (not available yet) are persisted on the aleph cloud network. 
 New VMs will try to use the latest version of this volume, with no guarantee against conflicts.
 
 ## Write a Python program
@@ -125,9 +125,9 @@ Have a look at it for a better understanding of what it does and how it works.
 
 ## Test it locally
 
-Before uploading your program on aleph.im, let's test it on your machine.
+Before uploading your program on aleph cloud, let's test it on your machine.
 
-Aleph.im uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
+Aleph cloud uses the standard [ASGI interface](https://asgi.readthedocs.io/en/latest/introduction.html) to
 interface with programs written in Python. ASGI interfaces with many Python frameworks, including
 FastAPI but also [Django](https://www.djangoproject.com/) 
 or [Quart](https://github.com/pgjones/quart).
@@ -160,7 +160,7 @@ The `--reload` option will automatically reload your app when the code changes.
 > ℹ Installing uvicorn should add the `uvicorn` command to your shell. If it does not, use
 > `python -m uvicorn` to run it.
 
-## Upload your program on aleph.im
+## Upload your program on aleph cloud
 
 After installing [aleph-client](../../tools/aleph-client/index.md), you should have access to the `aleph` command:
 
@@ -186,19 +186,19 @@ Ref of runtime ? [bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29
 
 You should then get a response similar to the following: 
 ```
-Your program has been uploaded on aleph.im .
+Your program has been uploaded on aleph cloud .
 
 Available on:
   https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
 Visualise on:
-  https://explorer.aleph.im/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
 You may get the warning `Message failed to publish on IPFS and/or P2P`. 
 This is common and usually not an issue.
 
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph.im identifiers are too long to work
+> ℹ The second URL uses a hostname dedicated to your VM. Aleph cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [advanced](./advanced.md) section.
@@ -209,12 +209,12 @@ You can now run your program by opening one of the URLs above. Each URL is uniqu
 
 https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 
-This will automatically start your program inside a VM on the aleph.im Compute Resource Node behind
+This will automatically start your program inside a VM on the aleph cloud Compute Resource Node behind
 the `aleph.sh` domain name and serve your request.
 
 An important thing to notice is that we did not install any specific dependency for our program,
 despite relying on FastAPI.
-This is because the official aleph.im runtime is already pre-configured with several typical Python packages.
+This is because the official aleph cloud runtime is already pre-configured with several typical Python packages.
 Of course, you can customize your program to add your own requirements.
 Refer to [Adding Python dependencies to a program](./dependency_volume.md) for more information.
 

--- a/tmp-backup/computing/functions/index.md
+++ b/tmp-backup/computing/functions/index.md
@@ -1,6 +1,6 @@
-# Computing on Aleph.im
+# Computing on Aleph Cloud
 
-Aleph.im offers a decentralized computing framework that allows users to run
+Aleph Cloud offers a decentralized computing framework that allows users to run
 applications on the network.
 
 Two execution models are available:
@@ -41,7 +41,7 @@ On how to deploy a simple Python microVM, see our [Python microVM guide](/devhub
 
 ## Persistent Execution {#persistent-execution}
 
-When a program is created with persistent execution enabled, the aleph.im scheduler will find a Compute Resource Node
+When a program is created with persistent execution enabled, the aleph cloud scheduler will find a Compute Resource Node
 (CRN) with enough resources to run the program and schedule the program to start on that node.
 
 Persistent programs are designed to always run exactly once, and the scheduler will reallocate the program on another
@@ -107,7 +107,7 @@ uvicorn main:app --reload
 
 ### Step 2: Run a program in a persistent manner
 
-To run the program in a persistent manner on the aleph.im network, use: 
+To run the program in a persistent manner on the aleph cloud network, use: 
 
 ```shell
 aleph program upload --persistent ./src/ main:app

--- a/tmp-backup/computing/instances/confidential/05-confidential-instance-troubleshooting.md
+++ b/tmp-backup/computing/instances/confidential/05-confidential-instance-troubleshooting.md
@@ -192,6 +192,6 @@ aleph instance confidential-init-session <vm_hash> --debug
 
 If you've tried the solutions above and are still experiencing issues:
 
-1. Join the [Aleph Cloud Discord](https://discord.gg/alephim) for community support
+1. Join the [Aleph Cloud Discord](https://discord.com/invite/alephcloud) for community support
 2. Open an issue on the [Aleph-VM GitHub repository](https://github.com/aleph-im/aleph-vm/issues)
-3. Contact the Aleph Cloud team directly through the [official website](https://aleph.im/contact)
+3. Contact the Aleph Cloud team directly through the [official website](https://aleph.cloud/contact)

--- a/tmp-backup/computing/instances/gpu-instances.md
+++ b/tmp-backup/computing/instances/gpu-instances.md
@@ -9,7 +9,7 @@ See [CLI Reference](../../tools/aleph-client/usage.md) or use `--help` for a qui
 
 ### Create an instance with GPU
 
-The CLI provides a streamlined command to create a GPU instance. You will be prompted to choose a specific GPU available on a compatible CRN (Compute Resource Node), where your instance will be deployed. Alternatively, you can create your GPU instance on [Twentysix Cloud](https://console.twentysix.cloud/).
+The CLI provides a streamlined command to create a GPU instance. You will be prompted to choose a specific GPU available on a compatible CRN (Compute Resource Node), where your instance will be deployed. Alternatively, you can create your GPU instance on [Aleph Cloud](https://app.aleph.cloud/).
 
 ```shell
 aleph instance gpu

--- a/tmp-backup/computing/runtimes/create-custom-runtimes.md
+++ b/tmp-backup/computing/runtimes/create-custom-runtimes.md
@@ -60,7 +60,7 @@ Running the script `create_disk_image.sh` as root will create a file named `root
 sudo ./create_disk_image.sh
 ```
 
-## 4. Publish the runtime on aleph.im
+## 4. Publish the runtime on aleph cloud
 
 ```shell
 aleph file upload ./rootfs.squashfs

--- a/tmp-backup/computing/runtimes/overview.md
+++ b/tmp-backup/computing/runtimes/overview.md
@@ -1,8 +1,8 @@
 # Introduction
 
-A **runtime** is an operating system and software stack that enables your program to run on the aleph.im network.
+A **runtime** is an operating system and software stack that enables your program to run on the aleph cloud network.
 
-Runtimes are customized Linux root filesystems that integrate with the aleph.im infrastructure and provide access to
+Runtimes are customized Linux root filesystems that integrate with the aleph cloud infrastructure and provide access to
 APIs, as well as quick responses to HTTP requests and other events.
 
 The project provides official runtimes with all you need for most programs and in most case you will simply use those.
@@ -15,9 +15,9 @@ Additionally, you can build and publish custom runtimes, and use any available r
 ## Use Existing Runtimes {#use-existing-runtimes}
 ### Official runtimes
 
-Aleph.im provides users with a default runtime based on [Debian 12 "bookworkm"](https://wiki.debian.org/DebianBookworm),
+Aleph cloud provides users with a default runtime based on [Debian 12 "bookworkm"](https://wiki.debian.org/DebianBookworm),
 the current stable version of the Debian project which can
-be [found on the Explorer](https://explorer.aleph.im/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/STORE/63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696).
+be [found on the Explorer](https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/STORE/63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696).
 This runtime is built with software available in the distribution, including Python 3.11 and Nodejs.
 
 There is also a [Debian 11 "bullseye"](https://wiki.debian.org/DebianBullseye) runtime, which is deprecated but kept for compatibilities reason.
@@ -54,7 +54,7 @@ Use these in your custom runtime by copying them to `/rootfs/sbin/init` and
 `/mnt/rootfs/root/init1.py` respectively.
 
 [Persistent Execution](../index.md#persistent-execution) may use the same init process, but this is not required. If you do not make use
-of the capabilities provided by the aleph.im ecosystem, using the default of your distribution 
+of the capabilities provided by the aleph cloud ecosystem, using the default of your distribution 
 (ex: [systemd](https://systemd.io/), [OpenRC](https://github.com/OpenRC/openrc), ...) should work as well.
 
 ## List of official runtimes

--- a/tmp-backup/examples/defi/index.md
+++ b/tmp-backup/examples/defi/index.md
@@ -828,8 +828,8 @@ const volumeData = await aleph.indexer.query(
 ## Community and Support
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your DeFi integrations, get help, and collaborate with other developers building on Aleph Cloud!

--- a/tmp-backup/examples/gaming/index.md
+++ b/tmp-backup/examples/gaming/index.md
@@ -865,8 +865,8 @@ Follow these steps to build your own gaming application with Aleph Cloud:
 ## Community and Support
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your gaming projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/tmp-backup/examples/index.md
+++ b/tmp-backup/examples/index.md
@@ -69,8 +69,8 @@ Before diving into these examples, we recommend familiarizing yourself with:
 If you have questions or need help implementing these examples, join our community:
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 We're excited to see what you build with Aleph Cloud!

--- a/tmp-backup/examples/nft/index.md
+++ b/tmp-backup/examples/nft/index.md
@@ -944,8 +944,8 @@ Follow these steps to build your own NFT application with Aleph Cloud:
 ## Community and Support
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your NFT projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/tmp-backup/examples/web3-apps/index.md
+++ b/tmp-backup/examples/web3-apps/index.md
@@ -418,8 +418,8 @@ Follow these steps to build your own web3 application with Aleph Cloud:
 ## Community and Support
 
 - [GitHub](https://github.com/aleph-im)
-- [Discord](https://discord.gg/aleph-im)
-- [Telegram](https://t.me/alephim)
+- [Discord](https://discord.com/invite/alephcloud)
+- [Telegram](https://t.me/alephcloud)
 - [Twitter](https://twitter.com/aleph_im)
 
 Join our community to share your projects, get help, and collaborate with other developers building on Aleph Cloud!

--- a/tmp-backup/getting-started/index.md
+++ b/tmp-backup/getting-started/index.md
@@ -73,11 +73,11 @@ account = client.get_account()
 
 ### 4. Try a Simple Example
 
-#### Store Data on Aleph.im
+#### Store Data on Aleph Cloud
 ::: code-group
 ```ts [TypeScript]
 // Store a simple message
-const content = { message: 'Hello, Aleph.im!' };
+const content = { message: 'Hello, Aleph Cloud!' };
 const result = await aleph.store.storeContent(
   account,
   content,
@@ -94,7 +94,7 @@ console.log(message);
 ```python [Python]
 # Store a simple message
 result = await client.create_store(
-    "Hello, Aleph.im!",
+    "Hello, Aleph Cloud!",
     tags=['example', 'hello-world']
 )
 
@@ -145,7 +145,7 @@ To help you get started, we've prepared some sample projects:
 
 1. Explore the [SDK documentation](/devhub/sdks/typescript/) for your preferred language
 2. Check out the [API Reference](/devhub/api/rest/) for detailed endpoint information
-3. Join the [Aleph.im Discord](https://discord.gg/alephim) to connect with the community
+3. Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) to connect with the community
 4. Browse [example projects](/devhub/examples/web3-apps/) for inspiration
 
 ## Getting Help
@@ -153,6 +153,6 @@ To help you get started, we've prepared some sample projects:
 If you encounter any issues or have questions:
 
 - Check the documentation for your specific use case
-- Join the [Aleph.im Discord](https://discord.gg/alephim) for community support
-- Visit the [Aleph.im GitHub](https://github.com/aleph-im) to report issues or contribute
-- Contact the Aleph.im team through the [official website](https://aleph.im/contact)
+- Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) for community support
+- Visit the [Aleph Cloud GitHub](https://github.com/aleph-im) to report issues or contribute
+- Contact the Aleph Cloud team through the [official website](https://aleph.cloud/contact)

--- a/tmp-backup/guides/custom-domains/setup.md
+++ b/tmp-backup/guides/custom-domains/setup.md
@@ -1,10 +1,10 @@
-# Adding a Custom Domain to Your Aleph.im Instance
+# Adding a Custom Domain to Your Aleph Cloud Instance
 
-Setting up a custom domain for your decentralized instance with Aleph.im can be accomplished with just a few steps. Please carefully follow this guide to ensure a smooth process.
+Setting up a custom domain for your decentralized instance with Aleph Cloud can be accomplished with just a few steps. Please carefully follow this guide to ensure a smooth process.
 
 ## Overview
 
-Adding a custom domain to your Aleph.im instance involves:
+Adding a custom domain to your Aleph Cloud instance involves:
 
 1. Creating a CNAME record.
 2. Creating a TXT owner proof record.
@@ -22,7 +22,7 @@ Before you start, make sure you have:
 
 ## Step 1: Create a CNAME Record
 
-To add a custom domain, first, you need to create a CNAME record in your domain's DNS settings. The CNAME record will point your domain to your instance on Aleph.im.
+To add a custom domain, first, you need to create a CNAME record in your domain's DNS settings. The CNAME record will point your domain to your instance on Aleph Cloud.
 
 1. **Log into your domain provider's site.**
 2. **Navigate to your domain's DNS settings.** These settings are usually located in your domain control panel.
@@ -40,7 +40,7 @@ Save your changes before moving on to the next step.
 
 ## Step 2: Create a TXT Owner Proof Record
 
-Next, you need to create a TXT owner proof record in your domain's DNS settings. This record confirms that you own the domain associated with the Aleph.im instance.
+Next, you need to create a TXT owner proof record in your domain's DNS settings. This record confirms that you own the domain associated with the Aleph Cloud instance.
 
 1. **Still in your domain's DNS settings, create a new TXT record.**
    - For the `Name/Host/Alias` field, enter `_control.<<userdomain.com>>`.

--- a/tmp-backup/guides/indexing/evm-indexer.md
+++ b/tmp-backup/guides/indexing/evm-indexer.md
@@ -151,13 +151,13 @@ export default class MainDomain extends IndexerMainDomain {
     await super.init()
     await this.indexAccounts([
       {
-        // The `Aleph.im v2` ERC20 token contract on the network with id `ethereum-mainnet`
+        // The `Aleph Cloud v2` ERC20 token contract on the network with id `ethereum-mainnet`
         blockchainId: 'ethereum-mainnet',
         account: '0x27702a26126e0B3702af63Ee09aC4d1A084EF628',
         index: { logs: true },
       },
       {
-        // The `Aleph.im v2` ERC20 token contract on the network with id `ethereum-testnet`
+        // The `Aleph Cloud v2` ERC20 token contract on the network with id `ethereum-testnet`
         blockchainId: 'ethereum-testnet',
         account: '0xC751491ae7dec5139a219d6094EF3fAd540A6de1',
         index: { logs: true },
@@ -586,15 +586,14 @@ This structure supports a clear separation of concerns, making it easier to mana
 This guide has walked you through setting up an indexer for the ethereum blockchain, from initializing the project and configuring the indexer to storing event data and exposing it through a GraphQL API. With the provided structure and examples, you're well-equipped to customize and extend your indexer to suit your specific needs, whether by adding more blockchain networks, optimizing performance, or enhancing security.
 
 ### 10.1 Additional resources
-- Development support: [https://t.me/alephim/119590](https://t.me/alephim/119590)
+- Development support: [https://t.me/alephcloud/119590](https://t.me/alephcloud/119590)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
-- Infrastructure documentation: [docs.aleph.im](https://docs.aleph.im)
-- Web3 Cloud: [console.twentysix.cloud](https://console.twentysix.cloud)
+- Infrastructure documentation: [docs.aleph.cloud](https://docs.aleph.cloud)
+- Web3 Cloud: [app.aleph.cloud](https://app.aleph.cloud)
 
 ### 10.2 Social
-- X twentysix.cloud: [https://twitter.com/TwentySixCloud](https://twitter.com/TwentySixCloud)
-- X aleph.im: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
-- Community: [https://t.me/alephim](https://t.me/alephim)
+- X Aleph Cloud: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
+- Community: [https://t.me/alephcloud](https://t.me/alephcloud)
 - Medium: [https://medium.com/aleph-im](https://medium.com/aleph-im)
 
 ## 11 Example indexing other EVM networks (oasys homeverse)

--- a/tmp-backup/guides/indexing/index.md
+++ b/tmp-backup/guides/indexing/index.md
@@ -1,6 +1,6 @@
 # Indexing Framework
 
-The [aleph.im Indexer Framework](https://github.com/aleph-im/aleph-indexer-framework) is a node.js and [moleculer](https://moleculer.services/) based framework for building multithreaded indexers to be deployed on the Aleph.im network. It provides a scalable architecture for tracking and processing blockchain events across multiple networks simultaneously.
+The [aleph cloud Indexer Framework](https://github.com/aleph-im/aleph-indexer-framework) is a node.js and [moleculer](https://moleculer.services/) based framework for building multithreaded indexers to be deployed on the Aleph Cloud network. It provides a scalable architecture for tracking and processing blockchain events across multiple networks simultaneously.
 
 ## Overview
 

--- a/tmp-backup/guides/indexing/solana-idl-indexer.md
+++ b/tmp-backup/guides/indexing/solana-idl-indexer.md
@@ -72,7 +72,7 @@ npm run start
 
 If you wait for a moment you will see a message warning you that it is now running a GraphQL server on [http://localhost:8080](http://localhost:8080).
 
-## Deploying your Indexer to Aleph.im
+## Deploying your Indexer to Aleph Cloud
 To deploy your indexer, read this [documentation](https://github.com/aleph-im/aleph-indexer-library?tab=readme-ov-file#building-and-deploying-an-indexer)
 
 ## Supported Queries
@@ -514,4 +514,4 @@ It is generally not advised to modify these files, as they are generated from th
 The Aleph Indexer Generator simplifies the process of creating Solana indexers by generating all necessary boilerplate code.
 It provides a solid foundation for building a Solana indexer and can be extended with additional functionality following the provided architecture or the [EVM Indexer Guide](evm-indexer.md).
 
-If you have any questions or need help with the indexer generator, feel free to reach out to us on [Telegram](https://t.me/alephim) or open an issue on the [GitHub repository](https://github.com/aleph-im/aleph-indexer-library/issues).
+If you have any questions or need help with the indexer generator, feel free to reach out to us on [Telegram](https://t.me/alephcloud) or open an issue on the [GitHub repository](https://github.com/aleph-im/aleph-indexer-library/issues).

--- a/tmp-backup/guides/messages/index.md
+++ b/tmp-backup/guides/messages/index.md
@@ -1,26 +1,26 @@
 # Messages
 
-At its core, the aleph.im network is a messaging system.
-All the data that transits on the network is represented by aleph.im messages that represent
+At its core, the aleph cloud network is a messaging system.
+All the data that transits on the network is represented by aleph cloud messages that represent
 all the possible operations on the network.
 
-With aleph.im messages, you can, for example:
+With aleph cloud messages, you can, for example:
 
 * store files
 * pin content on IPFS
 * create decentralized programs
 * set up key/value databases.
 
-Users create, sign and transmit messages to the aleph.im network.
+Users create, sign and transmit messages to the aleph cloud network.
 This can be achieved in a variety of ways:
 
 * by posting a message to a Core Channel Node
-* by broadcasting the message on the aleph.im peer-to-peer network
-* by using the aleph.im smart contracts deployed on supported chains.
+* by broadcasting the message on the aleph cloud peer-to-peer network
+* by using the aleph cloud smart contracts deployed on supported chains.
 
 ## Message format
 
-An aleph.im message is made of multiple fields that can be split between header and content fields.
+An aleph cloud message is made of multiple fields that can be split between header and content fields.
 
 ### Header fields
 
@@ -59,7 +59,7 @@ Messages are uniquely identified by the `item_hash` field.
 This value is obtained by computing the hash of the `content` field. 
 Currently, the hash can be obtained in one of two ways. 
 If the content of the message is stored on IPFS, the `item_hash` of the message will be the CIDv0 of this content. 
-Otherwise, if the message is stored on aleph.im native storage or is included in the message, the item hash will be 
+Otherwise, if the message is stored on aleph cloud native storage or is included in the message, the item hash will be 
 the SHA256 hash of the message in hexadecimal encoding. 
 In the first case, the item type will be set to `ipfs`. 
 In the second case, the item type will either be `inline` if the content is included in the message (serialized as a

--- a/tmp-backup/guides/messages/object-types/forget.md
+++ b/tmp-backup/guides/messages/object-types/forget.md
@@ -1,9 +1,9 @@
 # Deleting messages
 
-The aleph.im protocol is GDPR-compliant.
+The aleph cloud protocol is GDPR-compliant.
 To achieve this objective, we allow users to delete their own data.
 This is implemented using a special message type called FORGET.
-By sending a FORGET message, users can delete one or more messages from the entire aleph.im network.
+By sending a FORGET message, users can delete one or more messages from the entire aleph cloud network.
 Users can forget any type of message, except for FORGET messages themselves.
 
 When a FORGET message is processed by a node, it will immediately mark the target message(s) as forgotten,

--- a/tmp-backup/guides/messages/object-types/programs.md
+++ b/tmp-backup/guides/messages/object-types/programs.md
@@ -1,6 +1,6 @@
 # Programs
 
-PROGRAM messages create a new application that can then be run on aleph.im VMs.
+PROGRAM messages create a new application that can then be run on aleph cloud VMs.
 
 ## Content format
 
@@ -32,7 +32,7 @@ The `content` field of a PROGRAM message must contain the following fields:
 },
 "runtime": {
   "address": "0x4cB66fDf10971De5c7598072024FFd33482907a5",
-  "comment": "Aleph.im Alpine Linux with Python 3.8"
+  "comment": "Aleph cloud Alpine Linux with Python 3.8"
 },
 "data": {
   "encoding": "tar.gzip",

--- a/tmp-backup/guides/messages/object-types/store.md
+++ b/tmp-backup/guides/messages/object-types/store.md
@@ -1,14 +1,14 @@
 # File storage
 
-Users can store files on the aleph.im network using STORE messages. 
+Users can store files on the aleph cloud network using STORE messages. 
 By publishing a STORE message, users can:
 
-* store a file in the native aleph.im storage system
-* pin an IPFS CID on the aleph.im network.
+* store a file in the native aleph cloud storage system
+* pin an IPFS CID on the aleph cloud network.
 
-STORE messages tell the aleph.im network to store data on behalf of the
+STORE messages tell the aleph cloud network to store data on behalf of the
 user. The data can either be pinned to IPFS or stored in the native
-aleph.im storage system depending on the content item type.
+aleph cloud storage system depending on the content item type.
 
 ## STORE message content format
 
@@ -24,7 +24,7 @@ following fields:
 
 ## Updating files
 
-While files on the aleph.im network are immutable, you can use the `ref` field of STORE messages to create
+While files on the aleph cloud network are immutable, you can use the `ref` field of STORE messages to create
 a virtual filename and update it.
 
 When posting a STORE message, you can specify a value of your own liking to the `ref` field (ex: `ref: my-dynamic-nft`).
@@ -33,5 +33,5 @@ If you do not specify a value, it is automatically set to the item hash of the S
 From that point, you can then update your file by sending additional STORE messages with the same `ref` value.
 These messages will be considered as updates of the original.
 
-> Updating a file does not delete the previous versions. Each file is preserved on the aleph.im network until you emit
+> Updating a file does not delete the previous versions. Each file is preserved on the aleph cloud network until you emit
 > a FORGET message targeting these files.

--- a/tmp-backup/guides/storage/types-of-storage/immutable-volume.md
+++ b/tmp-backup/guides/storage/types-of-storage/immutable-volume.md
@@ -24,7 +24,7 @@ Additional data can be provided to a program by bundling it in an immutable volu
 mksquashfs ./custom-data data.squashfs
 ```
 
-### 2. Publish the file on aleph.im
+### 2. Publish the file on aleph cloud
 
 ```shell
 aleph file upload ./data.squashfs
@@ -51,7 +51,7 @@ pip3 install -t ./packages -r ./requirements.txt
 mksquashfs ./packages packages.squashfs
 ```
 
-### 3. Publish the file on aleph.im
+### 3. Publish the file on aleph cloud
 
 ```shell
 aleph file upload ./packages.squashfs

--- a/tmp-backup/index.md
+++ b/tmp-backup/index.md
@@ -49,9 +49,9 @@ Get inspired by real-world examples:
 
 Join our developer community:
 
-- [Discord](https://discord.gg/alephim) - Connect with other developers and get support
+- [Discord](https://discord.com/invite/alephcloud) - Connect with other developers and get support
 - [GitHub](https://github.com/aleph-im) - Explore our open-source repositories
-- [Forum](https://forum.aleph.im) - Discuss technical topics and proposals
+- [Forum](https://forum.aleph.cloud) - Discuss technical topics and proposals
 
 ## Contribute
 

--- a/tmp-backup/sdks-and-tools/aleph-cli/commands/account.md
+++ b/tmp-backup/sdks-and-tools/aleph-cli/commands/account.md
@@ -1,6 +1,6 @@
 # Account Management
 
-The `account` command group helps you manage your Aleph.im identity, private keys, and account information.
+The `account` command group helps you manage your Aleph Cloud identity, private keys, and account information.
 
 ## Key Commands
 
@@ -15,7 +15,7 @@ The `account` command group helps you manage your Aleph.im identity, private key
 
 ## Creating or Importing a Key
 
-Before using most Aleph.im features, you'll need a private key:
+Before using most Aleph Cloud features, you'll need a private key:
 
 ```bash
 # Create a new Ethereum private key
@@ -55,7 +55,7 @@ aleph account show
 
 ## Chain Support
 
-Aleph.im supports multiple blockchains. Specify the chain when needed:
+Aleph Cloud supports multiple blockchains. Specify the chain when needed:
 
 ```bash
 # Create a key for a specific chain

--- a/tmp-backup/sdks-and-tools/aleph-cli/commands/file.md
+++ b/tmp-backup/sdks-and-tools/aleph-cli/commands/file.md
@@ -1,19 +1,19 @@
 # File Operations
 
-The `file` command group allows you to upload, pin, and manage files on IPFS through the Aleph.im network.
+The `file` command group allows you to upload, pin, and manage files on IPFS through the Aleph Cloud network.
 
 ## Key Commands
 
 | Command | Description |
 |---------|-------------|
-| `upload` | Upload a file to IPFS via Aleph.im |
-| `pin` | Pin an existing IPFS file on Aleph.im |
+| `upload` | Upload a file to IPFS via Aleph Cloud |
+| `pin` | Pin an existing IPFS file on Aleph Cloud |
 | `status` | Check the status of a file |
-| `forget` | Remove a file from Aleph.im pinning |
+| `forget` | Remove a file from Aleph Cloud pinning |
 
 ## Uploading Files
 
-Upload local files to IPFS through Aleph.im:
+Upload local files to IPFS through Aleph Cloud:
 
 ```bash
 # Upload a single file
@@ -28,7 +28,7 @@ aleph file upload /path/to/file.txt --channel ALEPH-MAIN
 
 ## Pinning Existing IPFS Content
 
-If you already have content on IPFS, you can pin it on Aleph.im:
+If you already have content on IPFS, you can pin it on Aleph Cloud:
 
 ```bash
 # Pin by IPFS hash
@@ -66,7 +66,7 @@ aleph file forget QmHash123456789 --reason "No longer needed"
 
 ### Storage Engines
 
-Aleph.im supports different storage backends:
+Aleph Cloud supports different storage backends:
 
 ```bash
 # Specify storage engine
@@ -75,7 +75,7 @@ aleph file upload /path/to/file.txt --storage-engine ipfs
 
 Available storage engines:
 - `ipfs` - InterPlanetary File System
-- `storage` - Aleph.im native storage
+- `storage` - Aleph Cloud native storage
 
 ### File Metadata
 

--- a/tmp-backup/sdks-and-tools/aleph-cli/commands/instance.md
+++ b/tmp-backup/sdks-and-tools/aleph-cli/commands/instance.md
@@ -1,6 +1,6 @@
 # Instance Management
 
-The `instance` command group allows you to create and manage full virtual machine instances on the Aleph.im network.
+The `instance` command group allows you to create and manage full virtual machine instances on the Aleph Cloud network.
 
 ## Key Commands
 
@@ -35,7 +35,7 @@ aleph instance create \
 
 ## Supported Operating Systems
 
-Aleph.im provides several base images:
+Aleph Cloud provides several base images:
 
 - `debian` - Debian Linux
 - `ubuntu` - Ubuntu Linux
@@ -116,7 +116,7 @@ aleph instance update INSTANCE_HASH \
 
 ## Payment Options
 
-Aleph.im offers two payment models:
+Aleph Cloud offers two payment models:
 
 ```bash
 # Create with staking payment (default)

--- a/tmp-backup/sdks-and-tools/aleph-cli/commands/program.md
+++ b/tmp-backup/sdks-and-tools/aleph-cli/commands/program.md
@@ -1,6 +1,6 @@
 # Program Deployment
 
-The `program` command group allows you to deploy and manage serverless functions (micro-VMs) on the Aleph.im network.
+The `program` command group allows you to deploy and manage serverless functions (micro-VMs) on the Aleph Cloud network.
 
 ## Key Commands
 
@@ -34,7 +34,7 @@ aleph program create \
 
 ## Supported Runtimes
 
-Aleph.im supports multiple programming languages:
+Aleph Cloud supports multiple programming languages:
 
 - `python-3.10` - Python 3.10
 - `node-18` - Node.js 18

--- a/tmp-backup/sdks-and-tools/aleph-cli/index.md
+++ b/tmp-backup/sdks-and-tools/aleph-cli/index.md
@@ -1,6 +1,6 @@
 # Aleph Cloud Command-Line Interface
 
-The Aleph Cloud CLI provides a powerful command-line interface to interact with all features of the Aleph.im network directly from your terminal.
+The Aleph Cloud CLI provides a powerful command-line interface to interact with all features of the Aleph Cloud network directly from your terminal.
 
 ## Installation
 
@@ -56,7 +56,7 @@ docker run --rm -ti \
 
 ## Command Overview
 
-The Aleph CLI is organized into logical command groups that correspond to different Aleph.im features:
+The Aleph CLI is organized into logical command groups that correspond to different Aleph Cloud features:
 
 | Command | Description |
 |---------|-------------|
@@ -68,7 +68,7 @@ The Aleph CLI is organized into logical command groups that correspond to differ
 | `instance` | Create and manage virtual machine instances |
 | `domain` | Configure custom domains for your deployments |
 | `node` | Get information about network nodes |
-| `pricing` | View pricing for Aleph.im services |
+| `pricing` | View pricing for Aleph Cloud services |
 
 ## Getting Started
 

--- a/tmp-backup/sdks-and-tools/python/index.md
+++ b/tmp-backup/sdks-and-tools/python/index.md
@@ -96,7 +96,7 @@ avax_account = EVMAccount(private_key=private_key, chain=Chain.AVAX) # With this
 ```python
 # Store a simple message 
 message, status = await client.create_store(
-    "Hello, Aleph.im!",
+    "Hello, Aleph Cloud!",
     extra_fields= {"tags": ["example", "hello-world"]}
 )
 
@@ -480,7 +480,7 @@ The SDK includes a command-line interface for common operations:
 
 ```bash
 # Store a message
-aleph store "Hello, Aleph.im!" --tags example,hello-world
+aleph store "Hello, Aleph Cloud!" --tags example,hello-world
 
 # Get a message
 aleph get QmHash123

--- a/tmp-backup/sdks-and-tools/typescript/index.md
+++ b/tmp-backup/sdks-and-tools/typescript/index.md
@@ -82,7 +82,7 @@ const account = aleph.ethereum.importAccount('0x1234567890abcdef1234567890abcdef
 ```javascript
 // Store a simple message
 const result = await aleph.storage.store(
-  'Hello, Aleph.im!',
+  'Hello, Aleph Cloud!',
   { tags: ['example', 'hello-world'] }
 );
 
@@ -173,7 +173,7 @@ console.log(response); // { message: 'Hello, Alice!' }
 // Deploy a VM
 const vmResult = await aleph.instance.create({
   name: 'web-server',
-  description: 'A web server running on Aleph.im',
+  description: 'A web server running on Aleph Cloud',
   cpu: 2,
   memory: 4, // GB
   disk: 20, // GB
@@ -352,7 +352,7 @@ function AlephComponent() {
   
   return (
     <div>
-      <h2>Data from Aleph.im</h2>
+      <h2>Data from Aleph Cloud</h2>
       <pre>{JSON.stringify(data, null, 2)}</pre>
     </div>
   );


### PR DESCRIPTION
## Description

This PR performs a comprehensive update of the documentation to align with the new Aleph Cloud branding and contributor guidelines.

### Key Changes

- **Branding & Links**
  - Replaced all user-facing references to "Aleph.im" with "Aleph Cloud" (except where "aleph-im" is required for URLs, APIs, or repo names).
  - Removed all references to "Twentysix Cloud".
  - Updated all community, GitHub, Telegram, and Discord links to point to the correct Aleph Cloud resources.
  - Updated navigation and homepage links to reference the correct GitHub organization and documentation sections.

- **Documentation Structure**
  - Created a new SDKs & CLI overview page at `/devhub/sdks-and-tools/` with absolute links to Python SDK, TypeScript SDK, and CLI documentation.
  - Updated the home page “Multiple SDKs” section to link to the new overview page.
  - Ensured all markdown documentation and asset links use absolute paths as required by project rules.

- **Assets & Images**
  - Audited and updated all image and asset references to use absolute paths (`/assets/...`) for consistent rendering and error-free builds.

- **Miscellaneous**
  - Improved headings and anchor links for better navigation.
  - Cleaned up outdated quick-start sections and redundant relative links.

---

**This update ensures the documentation is fully aligned with Aleph Cloud branding, contributor guidelines, and technical requirements for navigation, asset referencing, and build reliability.**