### PR TITLE
Feature: SDK & Client docs  IPV4

### DIFF
--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
@@ -29,10 +29,11 @@ aleph instance [OPTIONS] KEY_COMMAND [ARGS]...
 | `confidential-start` | Validate the authenticity of the VM and start it                                  |
 | `confidentia` | Create (optional), start and unlock a confidential VM (all-in-one command)        |
 | `gpu` | Create and register a new GPU instance on Aleph Cloud                                   |
+| `port-forwarder` | Manage port forwarding for instances (list, create, update, delete, refresh)               |
 
 ## Creating an Instance
 
-Create and register a new instance on Aleph Cloud
+Create and register a new instance on Aleph Cloud. When you create an instance, port 22 (SSH) is automatically set up with TCP port forwarding to enable immediate SSH access to your instance.
 
 ### Usage:
 
@@ -496,3 +497,7 @@ Common issues and solutions:
 - **SSH connection failures**: Verify your SSH key was properly added and the instance is running
 - **Performance issues**: Consider increasing CPU, memory, or using a GPU instance
 - **Payment errors**: Ensure you have sufficient ALEPH tokens for staking or PAYG balance
+
+## Related Commands
+
+For detailed documentation on port forwarding functionality, see the [port-forwarder documentation](port-forwarder.md).

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/port-forwarder.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/port-forwarder.md
@@ -1,0 +1,211 @@
+# Port Forwarding Management
+
+The `port-forwarder` command group allows you to manage port forwarding for your instances, enabling external access to specific ports on your VMs through IPv4 addresses.
+
+## Overall Usage
+
+```bash
+aleph instance port-forwarder [OPTIONS] KEY_COMMAND [ARGS]...
+```
+
+### Options
+
+| Command | Description |
+|---------|-------------|
+| `--help` | Show the help prompt and exit |
+
+### Key Commands
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all port forwards for a given address and/or item hash |
+| `create` | Create a new port forward for a specific item hash |
+| `update` | Update an existing port forward for a specific item hash |
+| `delete` | Delete a port forward or all port forwards for a specific item hash |
+| `refresh` | Ask a CRN to fetch the latest port configurations from sender aggregates |
+
+## Listing Port Forwards
+
+List all port forwards for a given address and/or specific item hash.
+
+### Usage
+
+```bash
+aleph instance port-forwarder list [OPTIONS]
+```
+
+#### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--address` | TEXT | Target address to list port forwards for |
+| `--item-hash` | TEXT | Filter results to a specific item hash |
+| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
+| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
+| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using |
+| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
+| `--help` | | Show this message and exit |
+
+```bash
+# List all port forwards for your account
+aleph instance port-forwarder list
+
+# List port forwards for a specific instance
+aleph instance port-forwarder list --item-hash YOUR_INSTANCE_HASH
+
+```
+
+## Creating a Port Forward
+
+Create a new port forward for a specific item hash. Note that when you create an instance, port 22 (SSH) is automatically forwarded with TCP enabled.
+
+### Usage
+
+```bash
+aleph instance port-forwarder create [OPTIONS] ITEM_HASH PORT
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
+| `PORT` | INTEGER | Port number to forward (1-65535) |
+
+#### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--tcp / --no-tcp` | | Enable TCP forwarding for this port [default: tcp] |
+| `--udp / --no-udp` | | Enable UDP forwarding for this port [default: no-udp] |
+| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
+| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
+| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using |
+| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
+| `--help` | | Show this message and exit |
+
+```bash
+# Create a TCP port forward for port 80
+aleph instance port-forwarder create YOUR_INSTANCE_HASH 80
+
+# Create a UDP port forward for port 53
+aleph instance port-forwarder create YOUR_INSTANCE_HASH 53 --no-tcp --udp
+
+# Create a port forward for port 443 with both TCP and UDP
+aleph instance port-forwarder create YOUR_INSTANCE_HASH 443 --tcp --udp
+```
+
+## Updating a Port Forward
+
+Update an existing port forward for a specific item hash.
+
+### Usage
+
+```bash
+aleph instance port-forwarder update [OPTIONS] ITEM_HASH PORT
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
+| `PORT` | INTEGER | Port number to update (1-65535) |
+
+#### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--tcp / --no-tcp` | | Enable TCP forwarding for this port [default: tcp] |
+| `--udp / --no-udp` | | Enable UDP forwarding for this port [default: no-udp] |
+| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
+| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
+| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using |
+| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
+| `--help` | | Show this message and exit |
+
+```bash
+# Update port 80 to use both TCP and UDP
+aleph instance port-forwarder update YOUR_INSTANCE_HASH 80 --tcp --udp
+
+# Update port 443 to use TCP only
+aleph instance port-forwarder update YOUR_INSTANCE_HASH 443 --tcp --no-udp
+```
+
+## Deleting a Port Forward
+
+Delete a port forward or all port forwards for a specific item hash.
+
+### Usage
+
+```bash
+aleph instance port-forwarder delete [OPTIONS] ITEM_HASH
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
+
+#### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--port` | INTEGER | Port number to delete. If not specified, all port forwards will be deleted |
+| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
+| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
+| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using |
+| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
+| `--help` | | Show this message and exit |
+
+```bash
+# Delete port forward for port 80
+aleph instance port-forwarder delete YOUR_INSTANCE_HASH --port 80
+
+# Delete all port forwards for an instance
+aleph instance port-forwarder delete YOUR_INSTANCE_HASH
+```
+
+## Refreshing Port Configurations
+
+Ask a CRN to fetch the latest port configurations from sender aggregates.
+
+### Usage
+
+```bash
+aleph instance port-forwarder refresh [OPTIONS] ITEM_HASH
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
+
+#### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
+| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
+| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using |
+| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
+| `--help` | | Show this message and exit |
+
+```bash
+# Refresh port configurations for an instance
+aleph instance port-forwarder refresh YOUR_INSTANCE_HASH
+```
+
+## Important Notes
+
+1. **Automatic SSH Port**: When you create an instance, we also create aggregate for port 22 (SSH)  allowing you to SSH into your instance immediately.
+
+2. **IPv4 Access**: The port-forwarder functionality provides IPv4 access to your instances, making them accessible from systems that don't support IPv6.
+
+3. **Port Limitations**: You can forward any port in the valid range (1-65535), but some CRNs may restrict certain ports for security reasons.
+
+4. **Protocol Options**: You can choose to forward TCP, UDP, or both for each port.
+
+5. **Authorization**: You must be the owner of the instance to manage its port forwards.

--- a/docs/devhub/sdks-and-tools/python-sdk/index.md
+++ b/docs/devhub/sdks-and-tools/python-sdk/index.md
@@ -694,8 +694,130 @@ async def get_user(email: str):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 ```
+## Custom Services
+### Scheduler
+Get scheduler plan
+```python
+from aleph.sdk.types import SchedulerPlan
+data: SchedulerPlan  = await client.scheduler.get_plan() # get info about all the VM (where should they be scheduled)
+```
+Get node used by scheduler
+```python
+from aleph.sdk.types import SchedulerNodes
+node_info: SchedulerNodes = await client.scheduler.get_scheduler_node()
+```
+
+Get allocations of an Hold instance
+```python
+from aleph.sdk.types import AllocationItem
+from aleph_message.models import ItemHash
+allocation: AllocationItem = await client.scheduler.get_allocation(
+    ItemHash("ItemHASH")
+)
+```
 
 
+### CRN
+Get Last version of aleph-cm
+
+``` python
+crn_version = client.crn.get_last_crn_version()
+```
+
+# Get list of CRN
+```python
+crn_list = client.crn.get_crns_list(only_active=False) # Default to True
+```
+
+Get Executions info of a vm
+```python
+from aleph_message.models import ItemHash
+from aleph.sdk.types import CrnExecutionV2, CrnExecutionV1
+from typing import Optional, Union
+vm: Optional[Union[CrnExecutionV1, CrnExecutionV2]] = client.crn.get_vm(
+    crn_address="address", item_hash=ItemHash("item_hash")
+)
+```
+
+Update Crn Instance config
+```python
+# This will 'ask' crn to refresh config of the instance (exemple after adding a new ports)
+await client.crn.update_instance_config(crn_address='URL', item_hash="itemhash")
+```
+
+### Instance
+Get all instances / allocations / executions for a specific address 
+```python
+instance: List[InstanceMessage] = await client.utils.get_instances("address")
+allocations = await client.utils.get_instances_allocations(instance)
+executions = await client.utils.get_instance_executions_info(allocations)
+```
+
+### DNS
+Get DNS for instances
+````python
+    from aleph_message.models import ItemHash
+    from aleph.sdk.types import Dns
+    from typing import List, Optional
+
+    dnsList: List[Dns] = await client.dns.get_public_dns() # Get all Dns
+    
+    dns: Optional[Dns] = await client.dns.get_dns_for_instance(item_hash=ItemHash('item_hash'))
+    
+    # Find DNS for a specific host
+    dns = await client.dns.get_public_dns_by_host('host_name')
+````
+
+### Port-Forwarder
+Get Ports Info
+```python
+from aleph_message.models import ItemHash
+from aleph.sdk.types import Ports
+# AlephHttpClient
+ports = await client.port_forwarder.get_ports('address')
+port: Optional[Ports] = await client.port_forwarder.get_port('address', ItemHash("item_hash"))
+
+# AuthenticatedAlephHttpClient
+ports = await client.port_forwarder.get_ports() # address is optional (taking account address)
+port: Optional[Ports] = await client.port_forwarder.get_port(ItemHash('item_hash')) # same
+```
+
+Create Port for an instances
+```python
+from aleph.sdk.types import Ports
+from aleph_message.models import ItemHash
+# AuthenticatedAlephHttpClient is required
+ports = Ports(
+    ports={
+        80: PortFlags(tcp=True, udp=False),
+        22: PortFlags(tcp=True, udp=False),
+    }
+)
+message, status = await client.port_forwarder.create_port(
+    ItemHash("item_hash"),
+    ports
+)
+```
+Updates the Ports
+```python
+ports = Ports(
+    ports={
+        80: PortFlags(tcp=False, udp=True),
+        22: None,
+    }
+)
+message, status = await client.port_forwarder.update_port(
+    item_hash=ItemHash("Item_Hash"),
+    ports=ports,
+)
+
+```
+Remove all the ports for a VM
+```python
+    message, status = await.client.port_forwarder.delete_ports(
+        item_hash=ItemHash("item_hash")
+    )
+```
 # Resources
 
 - [GitHub Repository](https://github.com/aleph-im/aleph-sdk-python)


### PR DESCRIPTION
This PR add:

Aleph-client
- documentations about `aleph instance port-forwarder` command,
- Update `aleph instance create` documentations since now by default we also create aggregate for port 22 at creations.

SDK:
- Documentations about the new "service" made on top of the base client:
    - CRN
    - Scheduler
    - DNS
    - Instance
    - Port-forwarder