### PR TITLE
docs(cli): migrate install + account workflow to the Rust CLI

### DIFF
--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/account.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/account.md
@@ -1,188 +1,260 @@
 # Account Management
 
-The `account` command group helps you manage your Aleph Cloud identity, private keys, and account information.
+The `account` command group helps you manage your Aleph Cloud identity, private keys, and account information. Keys are stored in the **OS keychain** - they never touch disk as plain files.
+
+::: tip Coming from the Python CLI?
+Run `aleph account migrate` to import the keys from your existing `~/.aleph-im/`
+configuration. Add `--dry-run` to preview what would be imported.
+:::
 
 ## Overall Usage
 
 ```bash
-aleph account [OPTIONS] KEY_COMMAND [ARGS]...
+aleph account <COMMAND> [OPTIONS]
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `create` | Generate a new private key and store it in the OS keychain |
+| `import` | Import an existing private key (hex, file, or Ledger) |
+| `use` | Set the default account used for signing |
+| `show` | Show details of an account (defaults to the active account) |
+| `list` | List all stored accounts |
+| `balance` | Show the balance of any address |
+| `export` | Export the private key of a local account |
+| `remove` | Remove an account from the keychain |
+| `alias` | Manage address aliases (bookmarks for external addresses) |
+| `migrate` | Migrate accounts from the Python CLI (`~/.aleph-im/`) |
+
+---
+
+## Creating an Account
+
+Generate a fresh private key and store it in the OS keychain under the given name. The key never touches disk.
+
+```bash
+aleph account create <NAME> [--chain <CHAIN>]
 ```
 
 ### Options
 
-| Command  | Description                   |
-| -------- | ----------------------------- |
-| `--help` | Show the help prompt and exit |
+| Option | Description |
+|--------|-------------|
+| `--chain <CHAIN>` | Chain for the new account (default: `eth`) |
 
-### Key Commands
+Supported chains include `eth`, `sol`, `bsc`, `arb`, `avax`, `base`, `op`, `pol`, and many others. Run `aleph account create --help` for the full list.
 
-| Command              | Description                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------ |
-| `create`             | Create or import a private key                                                                   |
-| `address`            | Display your public address(es)                                                                  |
-| `balance`            | Check your ALEPH token balance                                                                   |
-| `chain`              | Display the currently active chain                                                               |
-| `path`               | Display the directory path where your private keys, config file, and other settings are stored   |
-| `show`               | Display your current configuration                                                               |
-| `config`             | Configure your private key file and active chain                                                 |
-| `export-private-key` | Display your private key (use with caution)                                                      |
-| `sign-bytes`         | Sign a message using your private key                                                            |
-| `list`               | Display available private keys, along with currently active chain and account (from config file) |
-| `vouchers`           | Display detailed information about your vouchers.                                                |
-
-## Creating or Importing a Key
-
-### Usage
+### Examples
 
 ```bash
-aleph account create [OPTIONS]
+# Create an EVM account (default chain: eth)
+aleph account create alice
+
+# Create a Solana account
+aleph account create alice --chain sol
+
+# Set as the default signing account
+aleph account use alice
 ```
 
-#### Options
+---
 
-| Options | Argument | Description |
-|---------|----------|-------------|
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain of origin of your private key (ensuring correct parsing) |
-| `--replace / --no-replace` | | Overwrites private key file if it already exists [default: no-replace] |
-| `--active / --no-active` | | Loads the new private key after creation [default: active] |
-| `--key-format` | [hexadecimal, base32, base64] | Encoding format of the private key [default: hexadecimal] |
-| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
-| `--help` | | Show this message and exit |
+## Importing an Existing Key
 
-
-Before using most Aleph Cloud features, you'll need a private key:
+Import an existing private key into the OS keychain under a given name. Three sources are supported (mutually exclusive):
 
 ```bash
-# Create a new Ethereum private key
-aleph account create
-
-# Import an existing private key
-aleph account create --private-key YOUR_PRIVATE_KEY
-
-# Import from a file
-aleph account create --private-key-file /path/to/key.txt
+aleph account import <NAME> [SOURCE] [OPTIONS]
 ```
 
-## Accounts Config
+### Sources
 
-Configure your default account settings, including private key file, chain, and account type (hardware wallet or imported key).
+| Flag | Description |
+|------|-------------|
+| `--private-key <HEX>` | Hex-encoded private key on the command line. If omitted (and no other source given), the key is read from stdin so it does not appear in shell history. |
+| `--from-file <PATH>` | Read from a file containing a raw 32-byte binary key or a hex-encoded text key. |
+| `--ledger` | Use a Ledger hardware wallet. Combine with `--derivation-path` to override the default BIP44 path, and `--ledger-count` to fetch more than the default 5 candidate addresses. |
 
-### Usage
+### Additional Options
+
+| Option | Description |
+|--------|-------------|
+| `--chain <CHAIN>` | Chain for the imported account (default: `eth`) |
+| `--derivation-path <PATH>` | BIP44 derivation path override (only with `--ledger`) |
+| `--ledger-count <N>` | Number of addresses to fetch from the Ledger (only with `--ledger`, default: `5`) |
+
+### Examples
 
 ```bash
-aleph account config [OPTIONS]
+# Import via hex private key
+aleph account import alice --private-key 0xabcd1234...
+
+# Import from a key file
+aleph account import alice --from-file ~/keys/alice.key
+
+# Import via stdin (key does not appear in shell history)
+echo "0xabcd1234..." | aleph account import alice
+
+# Import from a Ledger hardware wallet (EVM only)
+aleph account import alice --ledger
+
+# Import a Ledger account with a custom derivation path
+aleph account import alice --ledger --derivation-path "44'/60'/0'/0/1"
 ```
 
-#### Options
+::: warning Ledger is EVM-only
+Ledger support is currently limited to EVM accounts. Importing a Solana Ledger
+account works, but signing with it does not, so the account is unusable for
+transactions. Use `aleph account create` or `aleph account import --from-file`
+for Solana keys.
+:::
 
-| Options          | Argument                                                                                                                                         | Description                                                            |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| `--private-key-file`  | FILE                                                                                                                                             | Path to the private key file (optional for Ledger)                   |
-| `--chain`        | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain of origin of your private key         |
-| `--address`      | TEXT                                                                                                                                             | Address to use (required for hardware wallet) |
-| `--account-type` | [imported, hardware] | Account type: `imported` for private key file, `hardware` for Ledger device |
-| `--derivation-path` | TEXT | Derivation path for Ledger (e.g., "44'/60'/0'/0/0") |
-| `--ledger-count` | INTEGER | Number of Ledger accounts to fetch [default: 5] |
-| `--non-it` | | Non-interactive mode. Only apply provided options without prompts |
-| `--help` | | Show this message and exit |
+---
+
+## Selecting the Default Account
+
+Set which stored account is used by default for all signing commands.
 
 ```bash
-# Make CLI use Ledger Accounts
-aleph account config --account-type hardware --address ledger_address --chain ETH
-
-# Make CLI use private key
-aleph account config --private-key-file path --chain ETH
-
-# Configure with a specific derivation path for Ledger
-aleph account config --account-type hardware --derivation-path "44'/60'/0'/0/0" --chain ETH
-
-# Non-interactive configuration
-aleph account config --non-it --private-key-file my_key.key --chain ETH
+aleph account use <NAME>
 ```
 
-## Checking Your Address and Balance
+### Example
 
 ```bash
-# Display your public address
-aleph account address
-
-# Check your ALEPH token balance
-aleph account balance
+aleph account use alice
 ```
 
-## Checking Voucher
+---
 
-```
-aleph account vouchers
-```
+## Inspecting Accounts
 
-## Managing Multiple Keys
+### Show Account Details
 
-The CLI supports multiple keys for different chains and hardware wallets (Ledger).
-
-### List Command
-
-Display available private keys, along with currently active chain and account.
+Display details for a specific account, or the active account if no name is given.
 
 ```bash
-aleph account list [OPTIONS]
+aleph account show [NAME]
 ```
 
-#### Options
+### List All Accounts
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `--ledger-count` | INTEGER | Number of Ledger accounts to display [default: 5] |
-| `--help` | | Show this message and exit |
+List every account known to the CLI: keys stored in the OS keychain *and*
+Ledger-backed accounts (which live on the device, not the keychain).
 
 ```bash
-# List all available keys
 aleph account list
-
-# List keys with more Ledger accounts
-aleph account list --ledger-count 10
-
-# Configure which key to use
-aleph account config
-
-# Show current configuration
-aleph account show
 ```
 
-## Chain Support
+### Check Balance
 
-Aleph Cloud supports multiple blockchains. Specify the chain when needed:
+Show the ALEPH balance for any address - accepts a local account name, an alias, or a raw `0x…` address. Defaults to the active account if omitted.
 
 ```bash
-# Create a key for a specific chain
-aleph account create --chain ETH
-
-# Check balance on a specific chain
-aleph account balance --chain SOL
+aleph account balance [ADDRESS]
 ```
 
-Supported chains include:
+#### Examples
 
-- ETH (Ethereum)
-- SOL (Solana)
-- BSC (Binance Smart Chain)
-- AVAX (Avalanche)
-- And many others (use `--help` to see all options)
+```bash
+# Balance of the active account
+aleph account balance
+
+# Balance by account name
+aleph account balance alice
+
+# Balance by raw address
+aleph account balance 0xYourAddress...
+```
+
+### Export a Private Key
+
+Display the private key for a local account. **Use with caution - never share your private key with anyone.**
+
+```bash
+aleph account export <NAME>
+```
+
+The CLI will ask for confirmation before printing the key. Pass `--yes` to skip the prompt.
+
+---
+
+## Removing an Account
+
+Remove an account from the OS keychain. The CLI will prompt you to type the account name to confirm.
+
+```bash
+aleph account remove <NAME>
+```
+
+Pass `-y` / `--yes` to skip the confirmation prompt.
+
+---
+
+## Aliases
+
+Aliases are bookmarks for external addresses - useful for labelling addresses you interact with frequently, without importing their keys.
+
+```bash
+aleph account alias add <NAME> <ADDRESS>
+aleph account alias list
+aleph account alias remove <NAME>
+```
+
+### Examples
+
+```bash
+# Bookmark an external address
+aleph account alias add treasury 0xAbCd1234...
+
+# List all aliases
+aleph account alias list
+
+# Remove an alias
+aleph account alias remove treasury
+```
+
+---
+
+## Migrating from the Python CLI
+
+If you previously used the Python-based CLI, your keys live in `~/.aleph-im/`. Import them into the Rust CLI's OS keychain with:
+
+```bash
+# Preview what would be imported (no changes made)
+aleph account migrate --dry-run
+
+# Perform the migration
+aleph account migrate
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--python-home <PATH>` | Path to the Python CLI config directory (defaults to `~/.aleph-im`) |
+| `--dry-run` | Show what would be imported without actually importing |
+
+---
+
+## Identity Overrides on Signing Commands
+
+Most commands that write to the network accept identity overrides so you can sign as a different account without changing the default:
+
+| Method | Usage |
+|--------|-------|
+| `--account <NAME>` | Use a named account from the keychain |
+| `--private-key <HEX>` | Provide a raw hex private key inline. `--chain <CHAIN>` is required when signing with a raw key. |
+| `ALEPH_PRIVATE_KEY` env var | Set a hex private key in the environment |
+
+---
 
 ## Security Considerations
 
-- **NEVER** share your private key with anyone
-- Use `export-private-key` only when absolutely necessary
-- Consider using hardware wallets for additional security
-- Back up your keys securely
-
-## Troubleshooting
-
-If you encounter issues:
-
-- Check your key path with `aleph account path`
-- Verify your configuration with `aleph account show`
-- Ensure you have the correct permissions for key files
-- Try recreating your key if it's corrupted
+- Keys are stored in the **OS keychain** - they are never written to disk as plain files.
+- **NEVER** share your private key with anyone.
+- Use `aleph account export` only when absolutely necessary, and treat the output as a secret.
+- Consider using a Ledger hardware wallet for high-value accounts.
+- Back up your keys securely before removing them with `aleph account remove`.

--- a/docs/devhub/sdks-and-tools/aleph-cli/index.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/index.md
@@ -4,99 +4,61 @@ The Aleph Cloud CLI provides a powerful command-line interface to interact with 
 
 ## Installation
 
-### Prerequisites
-
-Before installing the CLI, ensure you have the necessary dependencies:
-
 ::: code-group
-
-```bash [Linux]
-apt-get install -y python3-pip libsecp256k1-dev
+```sh [macOS]
+brew install aleph-im/homebrew-tap/aleph-cli
 ```
-
-```bash [macOS]
-brew tap cuber/homebrew-libsecp256k1
-brew install libsecp256k1
+```sh [Linux (Debian/Ubuntu)]
+curl -fsSL https://apt.aleph.im/install.sh | sudo bash
+sudo apt install aleph-cli
 ```
-
+```sh [Cargo (any platform)]
+cargo install aleph-cli
+```
 :::
 
-### Recommended Installation (pipx)
-
-We recommend using [pipx](https://github.com/pypa/pipx) to install the CLI:
-
-`pipx` installs tools in isolated environments, ensuring that it does not mess up with your system.
-
-```bash
-# Install pipx if you don't have it
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
-
-# Install Aleph CLI
-pipx install aleph-client
-```
-
-### Alternative Installation Methods
-
-::: code-group
-
-```bash [Python]
-python3 -m venv aleph-env
-source aleph-env/bin/activate
-pip install aleph-client
-```
-
-```bash [Docker]
-docker run --rm -ti \
-    -v $(pwd)/data:/data \
-    ghcr.io/aleph-im/aleph-client/aleph-client:master \
-    --help
-```
-
-:::
-::: info
-
-> ⚠️ Using _Docker_ will create an ephemeral key that will be discarded when the container stops.
-> :::
+Prebuilt binaries for Linux/macOS/Windows are also published at
+<https://github.com/aleph-im/aleph-rs/releases/latest>. After installing, enable
+shell completion with `aleph completions <bash|elvish|fish|powershell|zsh>`.
 
 ## Command Overview
 
-The Aleph CLI is organized into logical command groups that correspond to different Aleph Cloud features:
-
-| Options | Argument | Description |
-|---------|----------|-------------|
-| `--install-completion` | [bash / zsh / fish / powershell /pwsh] | Install completion for the specified shell. [default: None] |
-| `--show-completion` | [bash / zsh / fish / powershell / pwsh] | Show completion for the specified shell to copy it or customize the installation [default: None] |
-| `--help` | | Show the usage message |
+The Aleph CLI is organized into logical command groups. Run `aleph <group> --help` for full details on any group.
 
 | Command | Description |
 |---------|-------------|
-| `account` | Manage accounts, keys, and balances |
-| `message` | Create, find, and manage messages |
-| `aggregate` | Work with aggregate messages and permissions |
-| `file` | Upload, pin, and manage files on IPFS |
-| `program` | Deploy and manage serverless functions |
-| `instance` | Create and manage virtual machine instances |
-| `domain` | Configure custom domains for your deployments |
-| `node` | Get information about network nodes |
-| `pricing` | View pricing for Aleph Cloud services |
-| `about` | Display version information |
+| `account` | Manage local accounts and signing keys |
+| `credit` | Buy and manage Aleph credits |
+| `file` | Upload, download, and manage files |
+| `instance` | Create and manage VM instances |
+| `program` | Deploy and manage serverless functions / micro-VMs |
+| `aggregate` | Create aggregate key-value entries |
+| `post` | List, create, and amend posts |
+| `message` | Query, sync, and forget raw protocol messages |
+| `domain` | Manage custom domains attached to websites, programs, or instances |
+| `node` | Register, stake, and manage network nodes |
+| `authorization` | Manage delegated authorizations |
+| `config` | Manage CLI configuration (networks, CCN endpoints, etc.) |
+| `website` | Deploy and manage static websites |
 
 ## Getting Started {#getting-started}
 
 ### First-time Setup
 
-When using the CLI for the first time:
-
-Using private key :
+When using the CLI for the first time, create a new account or import an existing key:
 
 ```bash
-# Create a new Ethereum private key
-aleph account create
+# Create a new Ethereum account named "alice"
+aleph account create alice
 
-# Import an existing private key
-aleph account create --private-key YOUR_PRIVATE_KEY
+# Set it as the default for signing commands
+aleph account use alice
+
+# Verify your setup
+aleph account show
 ```
+
+See [Account Management](./commands/account.md) for the full workflow including imports, Ledger support, and key migration.
 
 ## Using Ledger
 
@@ -122,8 +84,11 @@ Make sure your Ledger device is:
 Then:
 
 ```bash
-# Configure ledger
-aleph account config --account-type external
+# Import a Ledger account named "ledger-main"
+aleph account import ledger-main --ledger
+
+# Set it as the default
+aleph account use ledger-main
 ```
 
 ### Checking Your Configuration
@@ -131,11 +96,8 @@ aleph account config --account-type external
 Verify your setup is working correctly:
 
 ```bash
-# Show your account configuration
+# Show your account details
 aleph account show
-
-# Display your public address
-aleph account address
 
 # Check your ALEPH token balance
 aleph account balance
@@ -145,8 +107,8 @@ aleph account balance
 
 If you encounter issues with the CLI:
 
-- Ensure you have the latest version: `pip install -U aleph-client`
-- Check that your private key is correctly configured: `aleph account show`
+- Ensure you have the latest version: update via your install method (`brew upgrade aleph-cli`, `sudo apt update && sudo apt install --only-upgrade aleph-cli`, or re-download the binary)
+- Check that your account is correctly configured: `aleph account show`
 - For permission errors, verify you have the correct permissions for the operation
 - If you find a bug, please [report an issue](https://github.com/aleph-im/support/issues)
 
@@ -160,96 +122,38 @@ Explore the detailed documentation for each command group:
 - [Program Deployment](./commands/program.md)
 - [Instance Management](./commands/instance.md)
 - [Port Forwarding](./commands/port-forwarder.md)
-- [Pricing Information](./commands/pricing.md)
 - [Aggregate Management](./commands/aggregate.md)
 - [Domain Configuration](./commands/domain.md)
 - [Node Computing](./commands/node.md)
 - [Credits Management](./commands/credits.md)
-- [About](./commands/about.md)
 
 ## Structure
 
 ```
-Accounts:
-├─ aleph account create
-├─ aleph account address
-├─ aleph account chain
-├─ aleph account path
-├─ aleph account show
-├─ aleph account config
-├─ aleph account export-private-key
-├─ aleph account sign-bytes
-├─ aleph account balance
-├─ aleph account list
-└─ aleph account vouchers
+aleph account   → create, import, use, show, list, remove, export, balance, migrate, alias
 
-Programs:
-├─ aleph program create (alias: upload)
-├─ aleph program update
-├─ aleph program delete
-├─ aleph program list
-├─ aleph program persist
-├─ aleph program unpersist
-├─ aleph program logs
-└─ aleph program runtime-checker
+aleph credit    → buy, transfer, history
 
-Instances (Compute / VMs):
-├─ aleph instance create
-├─ aleph instance delete
-├─ aleph instance list
-├─ aleph instance reboot
-├─ aleph instance allocate
-├─ aleph instance stop
-├─ aleph instance logs
-├─ aleph instance confidential-init-session
-├─ aleph instance confidential-start
-├─ aleph instance confidential
-├─ aleph instance gpu
-└─ aleph instance port-forwarder [list|create|update|delete|refresh]
+aleph file      → upload, download, list, pin, delete
 
-Files & Storage:
-├─ aleph file upload
-├─ aleph file pin
-├─ aleph file download
-├─ aleph file forget
-└─ aleph file list
+aleph instance  → create, list, show, start, stop, reboot, logs, ssh, delete, erase,
+                  price, port-forward (pfw), backup
 
-Messages:
-├─ aleph message get
-├─ aleph message find
-├─ aleph message post
-├─ aleph message amend
-├─ aleph message forget
-├─ aleph message watch
-└─ aleph message sign
+aleph program   → create, update, delete, list, show, persist, unpersist, logs
 
-Aggregates:
-├─ aleph aggregate post
-├─ aleph aggregate get
-├─ aleph aggregate list
-├─ aleph aggregate forget
-├─ aleph aggregate authorize
-├─ aleph aggregate revoke
-└─ aleph aggregate permissions
+aleph aggregate → create, get, list, forget
 
-Domains:
-├─ aleph domain add
-├─ aleph domain attach
-├─ aleph domain detach
-└─ aleph domain info
+aleph post      → create, amend, list
 
-Credits:
-├─ aleph credits show
-└─ aleph credits history
+aleph message   → get, list, forget, retry, sync
 
-Nodes & Network:
-├─ aleph node compute
-└─ aleph node core
+aleph domain    → list, add, attach, detach, remove
 
-Pricing:
-└─ aleph pricing [service]
+aleph node      → list (+ register/stake/link - see `aleph node --help`)
 
-Operations / Meta:
-├─ aleph about version
-└─ aleph --help
+aleph authorization → add, list, received, revoke
+
+aleph config    → network …, ccn …
+
+aleph website   → deploy, update, list, show, delete
 ```

--- a/docs/devhub/sdks-and-tools/index.md
+++ b/docs/devhub/sdks-and-tools/index.md
@@ -22,7 +22,7 @@ The Aleph Cloud TypeScript SDK (`@aleph-sdk/client`) enables seamless integratio
 
 The Aleph Cloud Command-Line Interface (CLI) allows you to interact with all features of the Aleph Cloud network directly from your terminal.
 
-- **Install:** `pipx install aleph-client` (recommended)
+- **Install:** `brew install aleph-im/homebrew-tap/aleph-cli` (macOS) or the [APT repo](/devhub/sdks-and-tools/aleph-cli/) (Linux)
 - [Getting Started](/devhub/sdks-and-tools/aleph-cli/index.md#getting-started)
 - [Troubleshooting](/devhub/sdks-and-tools/aleph-cli/index.md#troubleshooting)
 


### PR DESCRIPTION
## Summary

Part of the Python→Rust CLI docs migration. Rewrites install (binary/apt/brew/cargo) and the account-management workflow (OS keychain, named accounts, `account migrate`).

- **`aleph-cli/index.md`**: Replaces the `pipx`/`pip`/Docker install blocks with the canonical brew/APT/cargo install block; updates Troubleshooting to use platform-native upgrade commands; rewrites the ASCII command tree to reflect the Rust CLI groups; updates the Ledger setup example to use `aleph account import --ledger`
- **`commands/account.md`**: Full rewrite documenting the OS keychain workflow — `create`, `import` (private-key/file/ledger/stdin), `use`, `show`, `list`, `balance`, `export`, `remove`, `alias`, and `migrate`; removes Python-only commands (`config`, `path`, `sign-bytes`, `vouchers`, `export-private-key`); adds identity override table (`--account`, `--private-key`, `ALEPH_PRIVATE_KEY`)
- **`sdks-and-tools/index.md`**: Updates the CLI install one-liner to brew/APT (Python SDK line untouched)

## Test plan

- [x] `npm run docs:build` completes with `build complete`
- [x] Residual grep for `aleph-client`, `pipx install`, `account config`, `account path`, `account vouchers` returns nothing
- [x] Only 3 files changed in the commit
- [x] All command flags verified against `aleph account <cmd> --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)