### PR TITLE
docs(cli): migrate command-reference pages to the Rust CLI

### DIFF
--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/about.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/about.md
@@ -1,40 +1,71 @@
-# Aleph About
+# Version & Shell Completions
 
-## Overall Usage
+## Show Version
+
+Display the version of the installed Aleph CLI.
 
 ```bash
-aleph about [OPTIONS] COMMAND [ARGS]...
+aleph --version
 ```
 
-### Options
+This prints the version, commit hash, and build date in the form `aleph <version> (<commit> <date>)`.
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+## Shell Completions
 
-### Key Commands
-
-| Command   | Description            |
-| --------- | ---------------------- |
-| `version` | Show Aleph CLI version |
-
-## Show Aleph CLI Version
-
-Display the version information of Aleph CLI
+Generate a shell completion script and add it to your shell configuration. The `completions` command supports Bash, Elvish, Fish, PowerShell, and Zsh.
 
 ### Usage
 
 ```bash
-aleph about version [OPTIONS]
+aleph completions <SHELL>
 ```
 
-#### Options
+#### Arguments
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Argument | Description                                              |
+|----------|----------------------------------------------------------|
+| `SHELL`  | Target shell: `bash`, `elvish`, `fish`, `powershell`, `zsh` |
+
+### Examples
+
+For shells with a per-shell completions directory (Fish, Zsh with `fpath`),
+write the script there directly so it gets loaded on the next shell start:
 
 ```bash
-# Show the Aleph CLI version
-aleph about version
+# Fish
+aleph completions fish > ~/.config/fish/completions/aleph.fish
 ```
+
+For shells without a dedicated completions directory (Bash, plain Zsh setups),
+generate the script on the fly from your rc file. This adds *one* line to your
+rc and always uses the currently-installed CLI version:
+
+```bash
+# Bash
+echo 'source <(aleph completions bash)' >> ~/.bashrc
+
+# Zsh
+echo 'source <(aleph completions zsh)' >> ~/.zshrc
+
+# Elvish
+echo 'eval (aleph completions elvish | slurp)' >> ~/.config/elvish/rc.elv
+```
+
+If you'd rather not run `aleph` on every shell start (e.g. for startup time),
+cache the script to a file once and source the file instead:
+
+```bash
+mkdir -p ~/.local/share/aleph
+aleph completions bash > ~/.local/share/aleph/completions.bash
+echo 'source ~/.local/share/aleph/completions.bash' >> ~/.bashrc
+# Re-run the first two lines after upgrading `aleph` to refresh the cache.
+```
+
+PowerShell uses its profile script directly:
+
+```powershell
+aleph completions powershell | Out-File -FilePath $PROFILE -Append
+```
+
+After updating your rc / profile, reload your shell (e.g. `source ~/.bashrc`)
+or open a new terminal session.

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/aggregate.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/aggregate.md
@@ -1,5 +1,7 @@
 # Aggregate Management
 
+The `aggregate` command group allows you to create and manage key-value aggregate entries on the Aleph Cloud network.
+
 ## Overall Usage
 
 ```bash
@@ -8,102 +10,88 @@ aleph aggregate [OPTIONS] COMMAND [ARGS]...
 
 ### Options
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Option   | Description                |
+| -------- | -------------------------- |
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ### Key Commands
 
-| Command       | Description                                                                          |
-| ------------- | ------------------------------------------------------------------------------------ |
-| `post`        | Create or update an aggregate by key or subkey                                       |
-| `get`         | Fetch an aggregate by key or subkeys                                                 |
-| `list`        | Display all aggregates associated with an account                                    |
-| `forget`      | Delete an aggregate by key or subkeys                                                |
-| `authorize`   | Grant specific publishing permissions to an address to act on behalf of this account |
-| `revoke`      | Revoke all publishing permissions from an address acting on behalf of this account   |
-| `permissions` | Display all permissions emitted by an account                                        |
+| Command  | Description                                              |
+| -------- | -------------------------------------------------------- |
+| `create` | Create a new aggregate message                           |
+| `get`    | Fetch a single aggregate by key                          |
+| `list`   | List every aggregate owned by an address                 |
+| `forget` | Forget entire aggregates by element hash                 |
 
-## Post an Aggregate
+## Create an Aggregate
 
-Create or update an aggregate by key or subkey
+Create a new aggregate message. Content can be provided as a JSON string via `--content`, or piped from stdin.
 
 ### Usage
 
 ```bash
-aleph aggregate post [OPTIONS] KEY CONTENT
+aleph aggregate create [OPTIONS] --key <KEY>
 ```
-
-#### Arguments
-
-| Argument  | Type | Description                                                                          |
-| --------- | ---- | ------------------------------------------------------------------------------------ |
-| `KEY`     | TEXT | Aggregate key to create or update                                                    |
-| `CONTENT` | TEXT | Aggregate content in JSON format and between single quotes. E.g., `{"a": 1, "b": 2}` |
 
 #### Options
 
-| Option                                 | Type | Description                                                                                             |
-| -------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| `--subkey`                             | TEXT | Specified subkey where the content will be replaced                                                     |
-| `--address`                            | TEXT | Target address. Defaults to the current account address                                                 |
-| `--channel`                            | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--inline / --no-inline`               |      | Inline [default: no-inline]                                                                             |
-| `--sync / --no-sync`                   |      | Sync response [default: no-sync]                                                                        |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with `--private-key-file`                                              |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                |
-| `--print-message / --no-print-message` |      | Print the messages after posting [default: no-print-message]                                            |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                                       |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                                |
-| `--help`                               |      | Show this message and exit                                                                              |
+| Option                      | Description                                                           |
+| --------------------------- | --------------------------------------------------------------------- |
+| `--key <KEY>`               | Aggregate key                                                         |
+| `--content <JSON>`          | JSON object content. If absent, reads from stdin                      |
+| `--channel <CHANNEL>`       | Channel name                                                          |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)            |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                        |
+| `--private-key <KEY>`       | Hex-encoded private key (or set `ALEPH_PRIVATE_KEY`)                 |
+| `--chain <CHAIN>`           | Signing chain (required with `--private-key`)                         |
+| `--dry-run`                 | Build and sign the message but don't submit it                        |
+| `--json`                    | Output results as JSON                                                |
+| `--help`                    | Show this message and exit                                            |
 
 ```bash
-# Post or update an aggregate
-aleph aggregate post KEY '{"a": 1, "b": 2}'
+# Create an aggregate
+aleph aggregate create --key mykey --content '{"a": 1, "b": 2}'
 
-# Post content for a specific subkey
-aleph aggregate post KEY '{"a": 1}' --subkey "subkey1"
+# Create from stdin
+echo '{"a": 1}' | aleph aggregate create --key mykey
 ```
 
 ## Get an Aggregate
 
-Fetch an aggregate by key or subkeys
+Fetch a single aggregate by key.
 
 ### Usage
 
 ```bash
-aleph aggregate get [OPTIONS] KEY
+aleph aggregate get [OPTIONS] <KEY>
 ```
 
 #### Arguments
 
-| Argument | Type | Description            |
-| -------- | ---- | ---------------------- |
-| `KEY`    | TEXT | Aggregate key to fetch |
+| Argument | Description            |
+| -------- | ---------------------- |
+| `KEY`    | Aggregate key to fetch |
 
 #### Options
 
-| Option                     | Type | Description                                                                                 |
-| -------------------------- | ---- | ------------------------------------------------------------------------------------------- |
-| `--subkeys`                | TEXT | Fetch specified subkey(s) only. Must be a comma-separated list. E.g., `key1` or `key1,key2` |
-| `--address`                | TEXT | Target address. Defaults to the current account address                                     |
-| `--private-key`            | TEXT | Your private key. Cannot be used with `--private-key-file`                                  |
-| `--private-key-file`       | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]    |
-| `--verbose / --no-verbose` |      | Display additional information [default: verbose]                                           |
-| `--debug / --no-debug`     |      | Enable debug logging [default: no-debug]                                                    |
-| `--help`                   |      | Show this message and exit                                                                  |
+| Option              | Description                                                  |
+| ------------------- | ------------------------------------------------------------ |
+| `--address <ADDR>`  | Owner address (defaults to the current account)              |
+| `--json`            | Output results as JSON                                       |
+| `--help`            | Show this message and exit                                   |
 
 ```bash
 # Fetch an aggregate by key
 aleph aggregate get KEY
 
-# Fetch specific subkeys of an aggregate
-aleph aggregate get KEY --subkeys key1,key2
+# Fetch the aggregate for a specific address
+aleph aggregate get KEY --address 0xYourAddress
 ```
 
 ## List Aggregates
 
-Display all aggregates associated with an account
+List every aggregate owned by an address.
 
 ### Usage
 
@@ -113,18 +101,14 @@ aleph aggregate list [OPTIONS]
 
 #### Options
 
-| Option                     | Type | Description                                                                              |
-| -------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--address`                | TEXT | Target address. Defaults to the current account address                                  |
-| `--private-key`            | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file`       | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--json / --no-json`       |      | Print as JSON instead of a rich table [default: no-json]                                 |
-| `--verbose / --no-verbose` |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`     |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                   |      | Show this message and exit                                                               |
+| Option              | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `--address <ADDR>`  | Owner address (defaults to the current account)          |
+| `--json`            | Output results as JSON                                   |
+| `--help`            | Show this message and exit                               |
 
 ```bash
-# List all aggregates associated with the current account
+# List all aggregates for the current account
 aleph aggregate list
 
 # List all aggregates as JSON
@@ -133,142 +117,59 @@ aleph aggregate list --json
 
 ## Forget an Aggregate
 
-Delete an aggregate by key or subkeys
+Forget entire aggregates by element hash. Resolves the `(sender, key)` pair from each hash and tombstones every AGGREGATE message under that key from that sender.
 
 ### Usage
 
 ```bash
-aleph aggregate forget [OPTIONS] KEY
+aleph aggregate forget [OPTIONS] [HASHES]...
 ```
 
 #### Arguments
 
-| Argument | Type | Description             |
-| -------- | ---- | ----------------------- |
-| `KEY`    | TEXT | Aggregate key to remove |
+| Argument    | Description                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| `HASHES...` | Item hashes of any AGGREGATE element message belonging to the aggregates |
 
 #### Options
 
-| Option                                 | Type | Description                                                                                             |
-| -------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| `--subkeys`                            | TEXT | Remove specified subkey(s) only. Must be a comma-separated list. E.g., `key1` or `key1,key2`            |
-| `--address`                            | TEXT | Target address. Defaults to the current account address                                                 |
-| `--channel`                            | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--inline / --no-inline`               |      | Inline [default: no-inline]                                                                             |
-| `--sync / --no-sync`                   |      | Sync response [default: no-sync]                                                                        |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with `--private-key-file`                                              |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                |
-| `--print-message / --no-print-message` |      | [default: no-print-message]                                                                             |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                                       |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                                |
-| `--help`                               |      | Show this message and exit                                                                              |
+| Option                      | Description                                                        |
+| --------------------------- | ------------------------------------------------------------------ |
+| `--reason <REASON>`         | Reason for forgetting                                              |
+| `--channel <CHANNEL>`       | Channel name                                                       |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)         |
+| `-y, --yes`                 | Skip the confirmation prompt and submit immediately                |
+| `--json`                    | Output results as JSON                                             |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                     |
+| `--private-key <KEY>`       | Hex-encoded private key                                            |
+| `--chain <CHAIN>`           | Signing chain                                                      |
+| `--dry-run`                 | Build and sign the message but don't submit it                     |
+| `--help`                    | Show this message and exit                                         |
 
 ```bash
-# Forget an aggregate by its key
-aleph aggregate forget KEY
+# Forget an aggregate by its element hash
+aleph aggregate forget ELEMENT_HASH
 
-# Forget specific subkeys of an aggregate
-aleph aggregate forget KEY --subkeys key1,key2
+# Forget with a reason
+aleph aggregate forget ELEMENT_HASH --reason "superseded"
 ```
 
-## Authorize an Address
+## Delegated Permissions
 
-Grant specific publishing permissions to an address to act on behalf of this account
-
-### Usage
+Delegated authorization has moved to the dedicated `authorization` command group. Use `aleph authorization --help` to see all options.
 
 ```bash
-aleph aggregate authorize [OPTIONS] ADDRESS
+# Grant publishing permission to a delegate
+aleph authorization add 0xDelegateAddress
+
+# Revoke permissions from a delegate
+aleph authorization revoke 0xDelegateAddress
+
+# List authorizations granted by your account
+aleph authorization list
+
+# List authorizations received from other accounts
+aleph authorization received
 ```
 
-#### Arguments
-
-| Argument  | Type | Description                                             |
-| --------- | ---- | ------------------------------------------------------- |
-| `ADDRESS` | TEXT | Target address. Defaults to the current account address |
-
-#### Options
-
-| Option                                 | Type                                                                                                                     | Description                                                                              |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--chain`                              | [ARB,AVAX,BASE,BLAST,BOB,BSC,CSDK,CYBER,DOT,ETH,FRAX,INK,LINEA,LISK,METIS,MODE,NEO,NULS,NULS2,OP,POL,SOL,TEZOS,WLD,ZORA] | Only on the specified chain                                                              |
-| `--types`                              | TEXT                                                                                                                     | Only for specified message types (comma-separated list)                                  |
-| `--channels`                           | TEXT                                                                                                                     | Only on specified channels (comma-separated list)                                        |
-| `--post-types`                         | TEXT                                                                                                                     | Only for specified post types (comma-separated list)                                     |
-| `--aggregate-keys`                     | TEXT                                                                                                                     | Only for specified aggregate keys (comma-separated list)                                 |
-| `--private-key`                        | TEXT                                                                                                                     | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file`                   | PATH                                                                                                                     | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |                                                                                                                          | [default: no-print-message]                                                              |
-| `--verbose / --no-verbose`             |                                                                                                                          | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`                 |                                                                                                                          | Enable debug logging [default: no-debug]                                                 |
-| `--help`                               |                                                                                                                          | Show this message and exit                                                               |
-
-```bash
-# Grant publishing permission to an address
-aleph aggregate authorize ADDRESS --chain ETH
-
-# Grant permission for specific aggregate keys
-aleph aggregate authorize ADDRESS --aggregate-keys key1,key2
-```
-
-## Revoke Permissions
-
-Revoke all publishing permissions from an address acting on behalf of this account
-
-### Usage
-
-```bash
-aleph aggregate revoke [OPTIONS] ADDRESS
-```
-
-#### Arguments
-
-| Argument  | Type | Description                                             |
-| --------- | ---- | ------------------------------------------------------- |
-| `ADDRESS` | TEXT | Target address. Defaults to the current account address |
-
-#### Options
-
-| Option                                 | Type | Description                                                                              |
-| -------------------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |      | [default: no-print-message]                                                              |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                               |      | Show this message and exit                                                               |
-
-```bash
-# Revoke publishing permissions from an address
-aleph aggregate revoke ADDRESS
-```
-
-## View Permissions
-
-Display all permissions emitted by an account
-
-### Usage
-
-```bash
-aleph aggregate permissions [OPTIONS]
-```
-
-#### Options
-
-| Option                     | Type | Description                                                                              |
-| -------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--address`                | TEXT | Target address. Defaults to the current account address                                  |
-| `--private-key`            | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file`       | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--json / --no-json`       |      | Print as JSON instead of a rich table [default: no-json]                                 |
-| `--verbose / --no-verbose` |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`     |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                   |      | Show this message and exit                                                               |
-
-```bash
-# View all permissions for the current account
-aleph aggregate permissions
-
-# View permissions in JSON format
-aleph aggregate permissions --json
-```
+For fine-grained control (restrict to specific chains, channels, message types, or aggregate keys), see `aleph authorization add --help`.

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/credits.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/credits.md
@@ -1,111 +1,154 @@
 # Credits Management
 
-The `credits` command group allows you to view and manage your Aleph Cloud credits, which can be used to pay for compute resources on the network.
+The credits commands allow you to view and manage your Aleph Cloud credits and account balance. Credits can be used to pay for compute resources on the network.
 
-## Overall Usage
+## Account Balance
 
-```bash
-aleph credits [OPTIONS] COMMAND [ARGS]...
-```
-
-### Options
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `--help` |  | Show this message and exit |
-
-### Key Commands
-
-| Command | Description |
-|---------|-------------|
-| `show` | Display the number of credits for a specific address |
-| `history` | Display the credit transaction history for an address |
-
-## Show Credits
-
-Display the number of credits for a specific address.
+Show the balance of any address (ALEPH tokens and credits).
 
 ### Usage
 
 ```bash
-aleph credits show [OPTIONS] [ADDRESS]
+aleph account balance [OPTIONS] [ADDRESS]
 ```
 
 #### Arguments
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `ADDRESS` | TEXT | Address of the wallet you want to check. If not provided, uses your current account |
+| Argument  | Description                                                                     |
+|-----------|---------------------------------------------------------------------------------|
+| `ADDRESS` | Address to query (hex `0x…`, local account name, or alias). Defaults to the active account |
 
 #### Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--json / --no-json` |  | Display output as JSON [default: no-json] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Option   | Description                |
+|----------|----------------------------|
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ```bash
-# Show credits for your current account
-aleph credits show
+# Show balance for your current account
+aleph account balance
 
-# Show credits for a specific address
-aleph credits show 0x1234567890abcdef...
+# Show balance for a specific address
+aleph account balance 0x1234567890abcdef...
 
-# Show credits as JSON output
-aleph credits show --json
-
-# Show credits for a specific address with JSON output
-aleph credits show 0x1234567890abcdef... --json
+# Show balance as JSON
+aleph account balance --json
 ```
 
-## Credits History
+## Credit History
 
-Display the credit transaction history for an address.
+Display the paginated credit history of an address.
 
 ### Usage
 
 ```bash
-aleph credits history [OPTIONS] [ADDRESS]
+aleph credit history [OPTIONS]
 ```
-
-#### Arguments
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `ADDRESS` | TEXT | Address of the wallet you want to check. If not provided, uses your current account |
 
 #### Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--page-size` | INTEGER | Number of elements per page [default: 100] |
-| `--page` | INTEGER | Current page number [default: 1] |
-| `--json / --no-json` |  | Display output as JSON [default: no-json] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Option                    | Description                                              |
+|---------------------------|----------------------------------------------------------|
+| `--address <ADDR>`        | Owner address (defaults to the current account)          |
+| `--page <N>`              | Page number (1-indexed) [default: 1]                     |
+| `--page-size <N>`         | Items per page (server-clamped) [default: 100]           |
+| `--json`                  | Output results as JSON                                   |
+| `--help`                  | Show this message and exit                               |
 
 ```bash
 # Show credit history for your current account
-aleph credits history
+aleph credit history
 
 # Show credit history for a specific address
-aleph credits history 0x1234567890abcdef...
+aleph credit history --address 0x1234567890abcdef...
 
 # Show credit history with pagination
-aleph credits history --page-size 50 --page 2
+aleph credit history --page-size 50 --page 2
 
 # Show credit history as JSON
-aleph credits history --json
+aleph credit history --json
+```
+
+## Buy Credits
+
+Buy Aleph credits by transferring ALEPH, USDC, or native ETH from your EVM account. ALEPH and USDC are ERC-20 transfers; ETH is a plain value transfer. Either way the transfer goes to the network's credit purchase address, and the protocol mints credits to your address once the transfer is confirmed.
+
+`--amount` is in human-readable token units (decimals OK), not credits. 1 USD purchases 1,000,000 credits.
+
+### Usage
+
+```bash
+aleph credit buy [OPTIONS] --token <TOKEN> --amount <AMOUNT>
+```
+
+#### Options
+
+| Option                  | Description                                                        |
+|-------------------------|--------------------------------------------------------------------|
+| `--token <TOKEN>`       | Token to pay with: `aleph`, `usdc`, or `eth`                       |
+| `--amount <AMOUNT>`     | Amount in human-readable units (e.g. `100` for 100 ALEPH, `0.05` for 0.05 ETH) |
+| `--rpc-url <URL>`       | Ethereum JSON-RPC endpoint override                                |
+| `-y, --yes`             | Skip the confirmation prompt and submit immediately                 |
+| `--json`                | Output results as JSON                                             |
+| `--account <ACCOUNT>`   | Named account (defaults to the active account)                     |
+| `--private-key <KEY>`   | Hex-encoded private key                                            |
+| `--chain <CHAIN>`       | Signing chain                                                      |
+| `--dry-run`             | Build and sign the message but don't submit it                     |
+| `--help`                | Show this message and exit                                         |
+
+```bash
+# Buy credits with ALEPH tokens
+aleph credit buy --token aleph --amount 100
+
+# Buy credits with USDC
+aleph credit buy --token usdc --amount 50.5
+
+# Buy credits with native ETH
+aleph credit buy --token eth --amount 0.05
+
+# Buy without confirmation prompt
+aleph credit buy --token usdc --amount 25 --yes
+```
+
+## Transfer Credits
+
+Transfer Aleph credits to another address. `--amount` is the number of credits (integer, not tokens) - 1 USD ≈ 1,000,000 credits.
+
+### Usage
+
+```bash
+aleph credit transfer [OPTIONS] --to <TO> --amount <AMOUNT>
+```
+
+#### Options
+
+| Option                      | Description                                                                        |
+|-----------------------------|------------------------------------------------------------------------------------|
+| `--to <ADDR>`               | Recipient address, account name, or alias                                          |
+| `--amount <N>`              | Number of credits to transfer (strictly positive integer)                          |
+| `--expiration <RFC3339>`    | Optional expiration timestamp; unspent credits are returned after this time        |
+| `-y, --yes`                 | Skip the confirmation prompt and submit immediately                                |
+| `--channel <CHANNEL>`       | Optional channel for the underlying POST message                                   |
+| `--json`                    | Output results as JSON                                                             |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                                     |
+| `--private-key <KEY>`       | Hex-encoded private key                                                            |
+| `--chain <CHAIN>`           | Signing chain                                                                      |
+| `--dry-run`                 | Build and sign the message but don't submit it                                     |
+| `--help`                    | Show this message and exit                                                         |
+
+```bash
+# Transfer credits to a named account or alias
+aleph credit transfer --to bob --amount 1000000
+
+# Transfer to a hex address
+aleph credit transfer --to 0xab12... --amount 500000
+
+# Transfer with an expiration date
+aleph credit transfer --to bob --amount 250000 \
+  --expiration 2026-12-31T23:59:59Z
 ```
 
 ## Related Commands
 
-- [Account Balance](./account.md#checking-your-address-and-balance) - View your ALEPH token balance alongside credits
 - [Pricing](./pricing.md) - View pricing information for services payable with credits

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/domain.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/domain.md
@@ -1,5 +1,7 @@
 # Domain Management
 
+The `domain` command group allows you to manage custom domains attached to websites, programs, or instances on the Aleph Cloud network.
+
 ## Overall Usage
 
 ```bash
@@ -8,148 +10,178 @@ aleph domain [OPTIONS] COMMAND [ARGS]...
 
 ### Options
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Option   | Description                |
+| -------- | -------------------------- |
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ### Key Commands
 
-| Command  | Description                        |
-| -------- | ---------------------------------- |
-| `add`    | Add and link a Custom Domain       |
-| `attach` | Attach resource to a Custom Domain |
-| `detach` | Unlink Custom Domain               |
-| `info`   | Show Custom Domain Details         |
+| Command  | Description                                               |
+| -------- | --------------------------------------------------------- |
+| `list`   | List all domains for an account                           |
+| `add`    | Add (or update) a domain entry pointing at a target       |
+| `attach` | Re-point an existing domain to a different target         |
+| `detach` | Clear a domain's target                                   |
+| `remove` | Remove a domain entry (soft-delete)                       |
+
+## List Domains
+
+List all domains for an account.
+
+### Usage
+
+```bash
+aleph domain list [OPTIONS]
+```
+
+#### Options
+
+| Option              | Description                                     |
+|---------------------|-------------------------------------------------|
+| `--address <ADDR>`  | Inspect another address's domains               |
+| `--json`            | Output results as JSON                          |
+| `--help`            | Show this message and exit                      |
+
+```bash
+# List domains for your account
+aleph domain list
+
+# List domains for a specific address
+aleph domain list --address 0xYourAddress
+
+# List domains as JSON
+aleph domain list --json
+```
 
 ## Add a Custom Domain
 
-Add and link a Custom Domain
+Add (or update) a domain entry pointing at a target (website name or message hash).
 
 ### Usage
 
 ```bash
-aleph domain add [OPTIONS] FQDN
+aleph domain add [OPTIONS] --target <TARGET> <DOMAIN>
 ```
 
 #### Arguments
 
-| Argument | Type | Description                                     |
-| -------- | ---- | ----------------------------------------------- |
-| `FQDN`   | TEXT | Fully Qualified Domain Name (e.g., aleph.cloud) |
+| Argument | Description                                     |
+|----------|-------------------------------------------------|
+| `DOMAIN` | Fully Qualified Domain Name (e.g. `aleph.cloud`) |
 
 #### Options
 
-| Option               | Type                      | Description                                                                              |
-| -------------------- | ------------------------- | ---------------------------------------------------------------------------------------- |
-| `--target`           | [ipfs, program, instance] | Resource type to target                                                                  |
-| `--item-hash`        | TEXT                      | Item hash                                                                                |
-| `--owner`            | TEXT                      | Owner address. Defaults to current account address                                       |
-| `--ask / --no-ask`   |                           | Prompt user for confirmation [default: ask]                                              |
-| `--private-key`      | TEXT                      | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file` | PATH                      | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--help`             |                           | Show this message and exit                                                               |
+| Option                            | Description                                                          |
+|-----------------------------------|----------------------------------------------------------------------|
+| `--target <TARGET>`               | Website name (resolved against your `websites` aggregate) or a raw message hash |
+| `--kind <KIND>`                   | Target type [default: ipfs] [possible values: `ipfs`, `program`, `instance`] |
+| `--catch-all-path <PATH>`         | Catch-all path for IPFS sites (default: `/404.html`)                 |
+| `--force`                         | Overwrite existing entry without erroring                            |
+| `--channel <CHANNEL>`             | Channel name                                                         |
+| `--on-behalf-of <ADDR>`           | Sign on behalf of another address (requires authorization); the aggregate write and any website-name lookup target the owner |
+| `--account <ACCOUNT>`             | Named account (defaults to the active account)                       |
+| `--private-key <KEY>`             | Hex-encoded private key                                              |
+| `--chain <CHAIN>`                 | Signing chain                                                        |
+| `--dry-run`                       | Build and sign the message but don't submit it                       |
+| `--json`                          | Output results as JSON                                               |
+| `--help`                          | Show this message and exit                                           |
 
 ```bash
-# Add and link a custom domain
-aleph domain add aleph.cloud --target ipfs --owner 0xYourAddress
+# Add a domain pointing at a website or program hash
+aleph domain add --target ITEM_HASH example.com
 
-# Add and link a custom domain with confirmation
-aleph domain add aleph.cloud --target program --ask
+# Add a domain for an instance
+aleph domain add --target ITEM_HASH --kind instance example.com
+
+# Add on behalf of another address
+aleph domain add --target ITEM_HASH example.com --on-behalf-of 0xOwnerAddress
+
+# Overwrite an existing entry
+aleph domain add --target ITEM_HASH example.com --force
 ```
 
-## Attach Resource to Custom Domain
+## Attach a Domain to a Resource
 
-Attach resource to a Custom Domain
+Re-point an existing domain to a different target. Use `--on-behalf-of <ADDRESS>` for delegated updates.
 
 ### Usage
 
 ```bash
-aleph domain attach [OPTIONS] FQDN
+aleph domain attach [OPTIONS] <DOMAIN> --to <TARGET>
 ```
 
 #### Arguments
 
-| Argument | Type | Description                                     |
-| -------- | ---- | ----------------------------------------------- |
-| `FQDN`   | TEXT | Fully Qualified Domain Name (e.g., aleph.cloud) |
+| Argument | Description                                     |
+|----------|-------------------------------------------------|
+| `DOMAIN` | The domain to re-point                          |
 
 #### Options
 
-| Option               | Type | Description                                                                              |
-| -------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--item-hash`        | TEXT | Item hash                                                                                |
-| `--catch-all-path`   | TEXT | Choose a relative path to catch all unmatched routes or a 404 error                      |
-| `--ask / --no-ask`   |      | Prompt user for confirmation [default: ask]                                              |
-| `--private-key`      | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--help`             |      | Show this message and exit                                                               |
+| Option                      | Description                                                          |
+|-----------------------------|----------------------------------------------------------------------|
+| `--to <TARGET>`             | Website name or message hash                                         |
+| `--channel <CHANNEL>`       | Channel name                                                         |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)           |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                       |
+| `--private-key <KEY>`       | Hex-encoded private key                                              |
+| `--chain <CHAIN>`           | Signing chain                                                        |
+| `--dry-run`                 | Build and sign the message but don't submit it                       |
+| `--json`                    | Output results as JSON                                               |
+| `--help`                    | Show this message and exit                                           |
 
 ```bash
-# Attach resource to a custom domain
-aleph domain attach aleph.cloud --item-hash ITEM_HASH --catch-all-path /404
+# Attach a domain to a resource
+aleph domain attach example.com --to ITEM_HASH
 
-# Attach resource with confirmation
-aleph domain attach aleph.cloud --item-hash ITEM_HASH --ask
+# Attach on behalf of another address (delegated update)
+aleph domain attach example.com --to ITEM_HASH --on-behalf-of 0xOwnerAddress
 ```
 
-## Detach Custom Domain
+## Detach a Domain
 
-Unlink Custom Domain
+Clear a domain's target (entry is kept, message_id emptied).
 
 ### Usage
 
 ```bash
-aleph domain detach [OPTIONS] FQDN
+aleph domain detach [OPTIONS] <DOMAIN>
 ```
-
-#### Arguments
-
-| Argument | Type | Description                                     |
-| -------- | ---- | ----------------------------------------------- |
-| `FQDN`   | TEXT | Fully Qualified Domain Name (e.g., aleph.cloud) |
-
-#### Options
-
-| Option               | Type | Description                                                                              |
-| -------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--ask / --no-ask`   |      | Prompt user for confirmation [default: ask]                                              |
-| `--private-key`      | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--help`             |      | Show this message and exit                                                               |
 
 ```bash
 # Detach a custom domain
-aleph domain detach aleph.cloud
-
-# Detach a custom domain with confirmation
-aleph domain detach aleph.cloud --ask
+aleph domain detach example.com
 ```
 
-## Show Custom Domain Details
+## Remove a Domain Entry
 
-Fetch details of a Custom Domain
+Remove a domain entry (soft-delete: sets the entry to null).
 
 ### Usage
 
 ```bash
-aleph domain info [OPTIONS] FQDN
+aleph domain remove [OPTIONS] <DOMAIN>
 ```
-
-#### Arguments
-
-| Argument | Type | Description                                     |
-| -------- | ---- | ----------------------------------------------- |
-| `FQDN`   | TEXT | Fully Qualified Domain Name (e.g., aleph.cloud) |
 
 #### Options
 
-| Option               | Type | Description                                                                              |
-| -------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--private-key`      | TEXT | Your private key. Cannot be used with `--private-key-file`                               |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--help`             |      | Show this message and exit                                                               |
+| Option                      | Description                                                          |
+|-----------------------------|----------------------------------------------------------------------|
+| `--yes`                     | Skip the confirmation prompt                                         |
+| `--channel <CHANNEL>`       | Channel name                                                         |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)           |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                       |
+| `--private-key <KEY>`       | Hex-encoded private key                                              |
+| `--chain <CHAIN>`           | Signing chain                                                        |
+| `--dry-run`                 | Build and sign the message but don't submit it                       |
+| `--json`                    | Output results as JSON                                               |
+| `--help`                    | Show this message and exit                                           |
 
 ```bash
-# Show details of a custom domain
-aleph domain info aleph.cloud
+# Remove a domain entry
+aleph domain remove example.com
+
+# Remove without confirmation
+aleph domain remove example.com --yes
 ```

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/file.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/file.md
@@ -1,180 +1,210 @@
 # File Operations
 
-The `file` command group allows you to upload, pin, and manage files on IPFS through the Aleph Cloud network.
+The `file` command group allows you to upload, pin, and manage files on the Aleph Cloud network.
 
 ## Overall Usage
 
 ```bash
-aleph file [OPTIONS] KEY_COMMAND [ARGS]...
+aleph file [OPTIONS] COMMAND [ARGS]...
 ```
 
 ### Options
 
-| Command  | Description                   |
+| Option   | Description                   |
 | -------- | ----------------------------- |
 | `--help` | Show the help prompt and exit |
 
 ### Key Commands
 
-| Command | Description |
-|---------|-------------|
-| `upload` | Upload a file or directory to IPFS via Aleph Cloud |
-| `pin` | Pin an existing IPFS file on Aleph Cloud |
-| `download` | Download a file from Aleph Cloud |
-| `forget` | Remove a file from Aleph Cloud pinning |
-| `list` | List all files for a given address |
+| Command    | Description                                        |
+|------------|----------------------------------------------------|
+| `upload`   | Upload a file or directory and create a STORE message |
+| `pin`      | Pin an existing file by creating a STORE message for a known item hash |
+| `download` | Download a file by hash, message hash, or ref      |
+| `delete`   | Delete files by hash, releasing the matching STORE pins |
+| `list`     | List all files stored by an address                |
 
 ## Uploading Files
 
-Upload a file or directory to IPFS via Aleph Cloud. Files larger than 4MB are automatically uploaded using IPFS storage.
+Upload a file (or directory) and create a STORE message announcing it on the network. Storage engine defaults to `storage` (Aleph native, ≤ 100 MB) for files and `ipfs` for directories. Payment defaults to credits.
 
 ### Usage
 
 ```bash
-aleph file upload [OPTIONS] PATH
+aleph file upload [OPTIONS] <PATH>
 ```
 
 #### Arguments
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `PATH` | PATH | Path of the file or directory to upload |
+| Argument | Description                                |
+|----------|--------------------------------------------|
+| `PATH`   | Path of the file or directory to upload    |
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--storage-engine` | [storage, ipfs] | Storage engine to use. If not specified, automatically chooses based on file size (ipfs for files > 4MB) |
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--ref` | TEXT | Item hash of the message to update |
-| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
-| `--help` | | Show this message and exit |
-
-
-Upload / Update local files to IPFS through Aleph Cloud:
+| Option                          | Description                                                                                                |
+|---------------------------------|------------------------------------------------------------------------------------------------------------|
+| `--storage-engine <ENGINE>`     | `storage` (default for files) or `ipfs` (default for directories)                                         |
+| `--payment-type <TYPE>`         | `credit` (default) or `hold`                                                                               |
+| `--channel <CHANNEL>`           | Channel name                                                                                               |
+| `--ref <REFERENCE>`             | User-defined file reference for updates/versioning                                                         |
+| `--on-behalf-of <ADDR>`         | Sign on behalf of another address (requires authorization)                                                 |
+| `--account <ACCOUNT>`           | Named account (defaults to the active account)                                                             |
+| `--private-key <KEY>`           | Hex-encoded private key (or set `ALEPH_PRIVATE_KEY`)                                                      |
+| `--chain <CHAIN>`               | Signing chain (required with `--private-key`)                                                              |
+| `--dry-run`                     | Build and sign the message but don't submit it                                                             |
+| `--help`                        | Show this message and exit                                                                                 |
 
 ```bash
 # Upload a single file
-aleph file upload /path/to/file.txt
+aleph file upload ./report.pdf
 
-# Upload with a specific channel
-aleph file upload /path/to/file.txt --channel ALEPH-MAIN
+# Upload a directory (automatically uses IPFS)
+aleph file upload ./website/
 
-# Update a file from its item hash
-aleph file upload --ref ITEM_HASH /path/to/file.txt
+# Upload to IPFS explicitly
+aleph file upload ./big.bin --storage-engine ipfs
+
+# Upload and assign a stable reference name
+aleph file upload ./report.pdf --ref reports/q4
+
+# Upload to a specific channel
+aleph file upload ./data.bin --channel my-channel
 ```
 
-## Pinning Existing Files
+## Pinning an IPFS CID
 
-If you already have content on IPFS, you can pin it on Aleph Cloud:
+Tell the Aleph Cloud network to pin an existing IPFS CID. The CLI emits a STORE
+message referencing the CID; CRNs that subscribe to that channel then keep the
+content available, so it survives even if the original IPFS provider goes
+offline. This is the most common use of `aleph file pin`.
 
 ### Usage
 
-`aleph file pin [OPTIONS] ITEM_HASH`
+```bash
+aleph file pin [OPTIONS] <ITEM_HASH>
+```
 
 #### Arguments
 
-| Argument    | Type      | Description                     |
-| ----------- | --------- | ------------------------------- |
-| `ITEM_HASH` | ITEM_HASH | IPFS hash to pin on Aleph Cloud |
+| Argument    | Description                                    |
+|-------------|------------------------------------------------|
+| `ITEM_HASH` | The IPFS CID (e.g. `QmXoyp…`) to pin. A 64-character hex item hash is also accepted; it pins via the native `storage` engine instead of IPFS (rarely useful). |
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--ref` | TEXT | Item hash of the message to update |
-| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
-| `--help` | | Show this message and exit |
-
-Pin files on IPFS
+| Option                      | Description                                                  |
+|-----------------------------|--------------------------------------------------------------|
+| `--payment-type <TYPE>`     | `credit` (default) or `hold`                                 |
+| `--channel <CHANNEL>`       | Channel name                                                 |
+| `--ref <REFERENCE>`         | User-defined file reference                                  |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)   |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)               |
+| `--private-key <KEY>`       | Hex-encoded private key                                      |
+| `--chain <CHAIN>`           | Signing chain                                                |
+| `--dry-run`                 | Build and sign the message but don't submit it               |
+| `--help`                    | Show this message and exit                                   |
 
 ```bash
-# Pin by IPFS hash
-aleph file pin ITEM_HASH
+# Pin an IPFS CID
+aleph file pin QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
+
+# Pin a CID and tag it with a user-defined reference for later updates
+aleph file pin QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco --ref my-dataset-v1
 ```
 
-## Downloading Files from Aleph Network
+## Downloading Files
 
-Download a file from Aleph Cloud or display its information:
+Download a file by hash, message hash, or ref.
 
 ### Usage
 
-`aleph file download [OPTIONS] ITEM_HASH`
+```bash
+aleph file download [OPTIONS] [HASH]
+```
 
 #### Arguments
 
-| Argument    | Type      | Description                       |
-| ----------- | --------- | --------------------------------- |
-| `ITEM_HASH` | ITEM_HASH | hash to download from Aleph Cloud |
+| Argument | Description                         |
+|----------|-------------------------------------|
+| `HASH`   | File hash to download (direct access) |
 
 #### Options
 
-| Options                        | Type | Description                                                   |
-| ------------------------------ | ---- | ------------------------------------------------------------- |
-| `--use-ipfs / --no-use-ipfs`   |      | Download using IPFS instead of storage [default: no-use-ipfs] |
-| `--output-path`                | PATH | Output directory path [default: .]                            |
-| `--file-name`                  | TEXT | Output file name (without extension)                          |
-| `--file-extension`             | TEXT | Output file extension                                         |
-| `--only-info / --no-only-info` |      | [default: no-only-info]                                       |
-| `--verbose / --no-verbose`     |      | [default: verbose]                                            |
-| `--debug / --no-debug`         |      | [default: no-debug]                                           |
-| `--help`                       |      | Show this message and exit                                    |
+| Option                          | Description                                                                        |
+|---------------------------------|------------------------------------------------------------------------------------|
+| `--message-hash <HASH>`         | Download by STORE message hash (resolves file hash from message metadata)          |
+| `--ref <REFERENCE>`             | Download by user-defined file reference (requires `--owner`)                       |
+| `--owner <ADDR>`                | Owner address (required when downloading by `--ref`)                               |
+| `-o, --output <PATH>`           | Output file path (defaults to `./<file_hash>` in current directory)                |
+| `--stdout`                      | Write file contents to stdout instead of saving to a file                          |
+| `--json`                        | Output results as JSON                                                             |
+| `--help`                        | Show this message and exit                                                         |
 
 ```bash
-# Download a file from its ITEM_HASH
+# Download a file by its hash
 aleph file download ITEM_HASH
 
-# Download a file from its ITEM_HASH and renaming it as new_name
-aleph file download ITEM_HASH --file-name new_name
+# Download by STORE message hash
+aleph file download --message-hash MESSAGE_HASH
 
-# Download a file from its ITEM_HASH as a python program named new_name
-aleph file download ITEM_HASH --file-name new_name --file-extension .py
+# Download to a specific output path
+aleph file download ITEM_HASH -o ./my-file.pdf
+
+# Download a versioned file by ref
+aleph file download --ref reports/q4 --owner 0xYourAddress
 ```
 
-## Forgetting Files
+## Deleting Files
 
-Forget a file and his message on Aleph Cloud:
+Delete files by their content hash (IPFS CID or native hex), releasing the matching STORE pins. This operation is irreversible.
+
+> **Note:** Use `aleph message forget` instead when you need to forget a specific STORE *message* by its item hash (e.g. to remove a duplicate pin while keeping the file alive).
 
 ### Usage
 
-`aleph file forget [OPTIONS] ITEM_HASH(ES) [REASON]`
+```bash
+aleph file delete [OPTIONS] [HASHES]...
+```
 
 #### Arguments
 
-| Argument        | Type      | Description                                                                                   |
-| --------------- | --------- | --------------------------------------------------------------------------------------------- |
-| `ITEM_HASH(ES)` | ITEM_HASH | Hash(es) to forget. Must be a comma separated list. Example: 123...abc or 123...abc,456...xyz |
-| `REASON`        | TEXT      | Reason to forget [default: User deletion]                                                     |
+| Argument    | Description                                  |
+|-------------|----------------------------------------------|
+| `HASHES...` | File hashes to delete (IPFS CID or native hex) |
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--debug / --no-debug` | | Enable debug logging [default: no-debug] |
-| `--help` | | Show this message and exit |
+| Option                      | Description                                                        |
+|-----------------------------|--------------------------------------------------------------------|
+| `--reason <REASON>`         | Reason for deleting                                                |
+| `--channel <CHANNEL>`       | Channel name                                                       |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)         |
+| `-y, --yes`                 | Skip the confirmation prompt and submit immediately                |
+| `--json`                    | Output results as JSON                                             |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                     |
+| `--private-key <KEY>`       | Hex-encoded private key                                            |
+| `--chain <CHAIN>`           | Signing chain                                                      |
+| `--dry-run`                 | Build and sign the message but don't submit it                     |
+| `--help`                    | Show this message and exit                                         |
 
 ```bash
-# Forget a file by hash
-aleph file forget ITEM_HASH
+# Delete a file by IPFS CID
+aleph file delete Qmabc...
 
-# Forget with a reason
-aleph file forget ITEM_HASH --reason "File no longer needed"
+# Delete by native hex hash
+aleph file delete 9675a23e...
+
+# Delete multiple files with a reason
+aleph file delete Qmabc... QmDef... --reason "superseded"
+
+# Delete without confirmation
+aleph file delete Qmabc... -y
 ```
 
 ## Listing Files
 
-List all files for a given address:
+List the files stored by an address.
 
 ### Usage
 
@@ -184,18 +214,13 @@ aleph file list [OPTIONS]
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--address` | TEXT | Address you are interested in |
-| `--private-key` | TEXT | Your private key. Cannot be used with `--private-key-file` |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain for the address |
-| `--pagination` | INTEGER | Maximum number of files to return [default: 100] |
-| `--page` | INTEGER | Offset in pages [default: 1] |
-| `--sort-order`| INTEGER | Order in which files should be listed: -1 means most recent messages first, 1 means older messages first [default: -1] |
-| `--json / --no-json`| | Print as JSON instead of rich table [default: no-json] |
-| `--help` | | Show this message and exit |
-
+| Option                    | Description                                                                   |
+|---------------------------|-------------------------------------------------------------------------------|
+| `--address <ADDR>`        | Address to query (defaults to the current account)                            |
+| `--count <N>`             | Maximum number of files to display [default: 25]                              |
+| `--sort-order <ORDER>`    | Sort order by creation time: `asc` or `desc` [default: desc]                  |
+| `--json`                  | Output results as JSON                                                        |
+| `--help`                  | Show this message and exit                                                    |
 
 ```bash
 # List your own uploaded files
@@ -204,11 +229,11 @@ aleph file list
 # List files uploaded by a specific address
 aleph file list --address ADDRESS
 
-# List your own files from oldest to newest (ascending order)
-aleph file list --sort-order 1
+# List files from oldest to newest
+aleph file list --sort-order asc
 
-# List the 50 oldest files uploaded by a specific address
-aleph file list --address ADDRESS --sort-order 1 --pagination 50
+# List up to 50 files as JSON
+aleph file list --count 50 --json
 ```
 
 ## Troubleshooting
@@ -217,5 +242,5 @@ Common issues and solutions:
 
 - **File upload fails**: Check your network connection and file permissions
 - **Pin operation times out**: The IPFS network might be congested, try again later
-- **File not found**: Verify the hash is correct and the file exists on IPFS
+- **File not found**: Verify the hash is correct and the file exists on the network
 - **Permission errors**: Ensure you're using the correct account with proper permissions

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
@@ -5,189 +5,146 @@ The `instance` command group allows you to create and manage full virtual machin
 ## Overall Usage
 
 ```bash
-aleph instance [OPTIONS] KEY_COMMAND [ARGS]...
+aleph instance [OPTIONS] COMMAND [ARGS]...
 ```
 
 ### Options
 
-| Command  | Description                   |
+| Option   | Description                   |
 | -------- | ----------------------------- |
+| `--json` | Output results as JSON        |
 | `--help` | Show the help prompt and exit |
 
 ### Key Commands
 
-| Command | Description                                                                       |
-|---------|-----------------------------------------------------------------------------------|
-| `create` | Create a new VM instance                                                          |
-| `delete` | Delete an instance, unallocating all resources associated with it                 |
-| `list` | List all instances associated to an account                                       |
-| `reboot` | Reboot an instance                                                                |
-| `allocate` | Notify a CRN to start an instance (for Pay-As-You-Go and confidential instances only) |
-| `logs` | Retrieve the logs of an instance                                                  |
-| `stop` | Stop an instance |
-| `confidential-init-session` | Initialize a confidential communication session with the VM |
-| `confidential-start` | Validate the authenticity of the VM and start it |
-| `confidential` | Create (optional), start and unlock a confidential VM (all-in-one command) |
-| `gpu` | Create and register a new GPU instance on Aleph Cloud                                   |
-| `port-forwarder` | Manage port forwarding for instances (list, create, update, delete, refresh)               |
+| Command        | Description                                                                   |
+|----------------|-------------------------------------------------------------------------------|
+| `create`       | Create a new VM instance                                                      |
+| `delete`       | Forget an INSTANCE message (send a FORGET)                                    |
+| `list`         | List instances belonging to an account                                        |
+| `reboot`       | Reboot a VM instance                                                          |
+| `start`        | Start (allocate) a VM instance on the CRN                                     |
+| `stop`         | Stop a running VM instance                                                    |
+| `show`         | Show details of an instance                                                   |
+| `ssh`          | SSH into a dispatched VM instance                                             |
+| `erase`        | Erase a VM instance's data on the CRN                                         |
+| `price`        | Show pricing for an instance configuration                                    |
+| `backup`       | Manage VM backups (create / info / download / delete / restore)               |
+| `logs`         | Stream logs from a running VM instance                                        |
+| `port-forward` | Manage TCP/UDP port forwards for VMs, programs, or IPFS websites (alias: pfw) |
 
 ## Creating an Instance
 
-Create and register a new instance on Aleph Cloud. When you create an instance, port 22 (SSH) is automatically set up with TCP port forwarding to enable immediate SSH access to your instance.
+Create a new VM instance on Aleph Cloud. Sizing is specified in one of two ways:
 
-### Usage:
+- `--size <SLUG>`, e.g. `1vcpu-2gb`, `2vcpu-4gb`, `4vcpu-8gb`, `8vcpu-16gb`.
+- `--vcpus N --memory <SIZE> --disk-size <SIZE>`, with human-readable values (e.g. `4GB`, `512MiB`, `1TiB`).
 
-```bash
-aleph instance create [OPTIONS]
-```
+`--gpu <MODEL>` is independent: it requests a GPU and enforces a minimum size for that model. You can still combine it with `--size` (the minimum slug or any larger multiple) or with `--vcpus`/`--memory`. Use `aleph instance price --list-gpus` to see available models.
 
-#### Options
-
-| Options | Type | Description |
-|---------|------|-------------|
-| `--payment-type` | [hold, superfluid, credit, nft] | Payment method: holding tokens, credits, NFTs, or Pay-As-You-Go via token streaming |
-| `--payment-chain` | [AVAX, BASE, ETH, SOL] | Chain you want to use to pay for your instance |
-| `--hypervisor` | [qemu] | Hypervisor to use to launch your instance. QEMU is the only supported hypervisor (Firecracker is deprecated for instances) [default: qemu] |
-| `--name` | TEXT | Name of your new instance |
-| `--rootfs` | TEXT | Hash of the rootfs to use for your instance. Defaults to Ubuntu 22. You can also create your own rootfs and pin it |
-| `--compute-units` | INTEGER | Number of compute units to allocate. Compute units correspond to a tier that includes vcpus, memory, disk and gpu presets. For reference, run: aleph pricing --help |
-| `--vcpus` | INTEGER | Number of virtual CPUs to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides vCPUs only |
-| `--memory` | INTEGER | Maximum memory (RAM) in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides memory only |
-| `--rootfs-size` | INTEGER RANGE | Main VM partition size in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides disk only [x<=1953125] |
-| `--timeout-seconds` | FLOAT | If vm is not called after [timeout_seconds] it will shutdown [default: 30.0] |
-| `--ssh-pubkey-file` | PATH | Path to a public ssh key to be added to the instance [default: /home/$USER/.ssh/id_rsa.pub] |
-| `--address` | TEXT | Address of the payer. In order to delegate the payment, your account must be authorized beforehand to publish on the behalf of this address. See the docs for more info: https://docs.aleph.cloud/protocol/permissions/ |
-| `--crn-hash` | TEXT | Hash of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--crn-url` | TEXT | URL of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--confidential / --no-confidential` |  | Launch a confidential instance (requires creating an encrypted volume) [default: no-confidential] |
-| `--confidential-firmware` | TEXT | Hash to UEFI Firmware to launch confidential instance [default: ba5bb13f3abca960b101a759be162b229e2b7e93ecad9d1307e54de887f177ff] |
-| `--gpu / --no-gpu` |  | Launch an instance attaching a GPU to it [default: no-gpu] |
-| `--premium / --no-premium` |  | Use Premium GPUs (VRAM > 48GiB) |
-| `--skip-volume / --no-skip-volume` |  | Skip prompt to attach more volumes [default: no-skip-volume] |
-| `--persistent-volume` | TEXT | Persistent volumes are allocated on the host machine and are not deleted when the VM is stopped. Requires at least name, mount path, and size_mib. To add multiple, reuse the same argument. Example: --persistent-volume name=data,mount=/opt/data,size_mib=1000. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/persistent/ |
-| `--ephemeral-volume` | TEXT | Ephemeral volumes are allocated on the host machine when the VM is started and deleted when the VM is stopped. Requires at least mount path and size_mib. To add multiple, reuse the same argument. Example: --ephemeral-volume mount=/opt/tmp,size_mib=100 |
-| `--immutable-volume` | TEXT | Immutable volumes are pinned on the network and can be used by multiple VMs at the same time. They are read-only and useful for setting up libraries or other dependencies. Requires at least mount path and ref (volume message hash). use_latest is True by default, to use the latest version of the volume, if it has been amended. To add multiple, reuse the same argument. Example: --immutable-volume mount=/opt/packages,ref=25a3...8d94. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/immutable/ |
-| `--crn-auto-tac / --no-crn-auto-tac` |  | Automatically accept the Terms & Conditions of the CRN if you read them beforehand [default: no-crn-auto-tac] |
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |  | Print the message after creation [default: no-print-message] |
-| `--verbose / --no-verbose` |  | Display additional information [default: verbose] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
-
-
-### Resource Allocation
-
-When creating an instance, you have several options to specify your resource requirements:
-
-> **Note:** When using the Holding payment method (`--payment-type hold`), you can create instances up to tier 3. For higher tiers, use other payment methods like [Credits](./credits.md) or Pay-As-You-Go.
-
-1. **Using Compute Units**: The recommended approach is to use the `--compute-units` parameter, which provides preset resource configurations. To see available compute units and their associated resources for each instance type:
-
-   ```bash
-   # For standard instances
-   aleph pricing instance
-
-   # For confidential instances
-   aleph pricing confidential
-
-   # For GPU instances
-   aleph pricing gpu
-
-   # For all instance types
-   aleph pricing all
-   ```
-
-2. **Custom Resource Configuration**: You can also customize your resource allocation:
-   - Use `--compute-units` as a base configuration and override specific resources with `--vcpus`, `--memory`, or `--rootfs-size`
-   - If you specify all three parameters (`--vcpus`, `--memory`, and `--rootfs-size`), then `--compute-units` is not required
-   - If `--compute-units` is not set and you only specify some resource parameters (e.g., only `--vcpus`), the system will automatically select the closest tier for the remaining resources.
-
-```bash
-# Create an instance
-aleph instance create
-
-# Create an instance using hold payment and a specific config
-aleph instance create \
-  --payment-type nft \
-  --payment-chain BASE \
-  --compute-units 1 \
-  --skip-volume \
-  --rootfs debian12 \
-  --name vm-nft
-
-# Create an instance using PAYG and a specific CRN
-aleph instance create \
-  --payment-type superfluid \
-  --payment-chain BASE \
-  --compute-units 1 \
-  --skip-volume \
-  --rootfs debian12 \
-  --crn-url https://gpu-test-01.nergame.app \
-  --name vm-payg \
-  --crn-auto-tac
-
-# Create an instance using credits
-aleph instance create \
-  --payment-type credit \
-  --compute-units 1 \
-  --skip-volume \
-  --rootfs debian12 \
-  --crn-url https://gpu-test-01.nergame.app \
-  --name vm-credits \
-  --crn-auto-tac
-
-# Creating a confidential instance
-aleph instance confidential \
-  --payment-type nft \
-  --payment-chain BASE \
-  --compute-units 1 \
-  --skip-volume \
-  --crn-url https://coco-1.crn.aleph.sh \
-  --no-keep-session \
-  --rootfs debian12 \
-  --name vm-confidential \
-  --crn-auto-tac
-```
-
-## Deleting an Instance
-
-Delete an instance, unallocating all resources associated with it. Associated VM will be stopped and erased. Immutable volumes will not be deleted.
+An instance name (positional), `--image`, and at least one `--ssh-pubkey-file` are required. Image accepts a preset name (`ubuntu22`, `ubuntu24`, `ubuntu26`, `debian12`) or an item hash. Pin to a specific node with `--crn-hash`. For an interactive walkthrough, pass `-i` / `--interactive`.
 
 ### Usage
 
 ```bash
-aleph instance delete [OPTIONS] ITEM_HASH
+aleph instance create [OPTIONS] <NAME>
+```
+
+#### Options
+
+| Option                   | Description                                                                    |
+|--------------------------|--------------------------------------------------------------------------------|
+| `--image <IMAGE>`        | Root filesystem image: preset name or item hash (hex or IPFS CID)             |
+| `--size <SIZE>`          | Instance size slug (e.g. `1vcpu-2gb`, `4vcpu-8gb`)                            |
+| `--vcpus <N>`            | Number of virtual CPUs (overrides `--size`)                                    |
+| `--memory <SIZE>`        | Memory size, e.g. `2GB`, `2048MB` (overrides `--size`)                        |
+| `--disk-size <SIZE>`     | Disk size, e.g. `20GB`, `1TiB` (required unless `--size` is used)             |
+| `--ssh-pubkey-file PATH` | Path to SSH public key file; can be repeated for multiple keys                 |
+| `--gpu <MODEL>`          | GPU model name (e.g. `rtx4090`, `a100`, `l40s`); can be repeated              |
+| `--crn-hash <HASH>`      | CRN node hash - pins the instance to a specific compute node                  |
+| `--on-behalf-of <ADDR>`  | Sign on behalf of another address (requires an authorization from that address)|
+| `--persistent-volume`    | `name=N,mount=PATH,size=SIZE[,persistence=host\|store]`; can be repeated      |
+| `--ephemeral-volume`     | `mount=PATH,size=SIZE`; can be repeated                                        |
+| `--immutable-volume`     | `ref=HASH,mount=PATH[,use_latest=BOOL]`; can be repeated                      |
+| `--confidential`         | Launch a confidential VM (AMD SEV)                                             |
+| `--channel <CHANNEL>`    | Channel name                                                                   |
+| `--account <ACCOUNT>`    | Named account (defaults to the active account)                                 |
+| `--private-key <KEY>`    | Hex-encoded private key (or set `ALEPH_PRIVATE_KEY`)                          |
+| `--chain <CHAIN>`        | Signing chain (required with `--private-key`)                                  |
+| `--dry-run`              | Build and sign the message but don't submit it                                 |
+| `-i, --interactive`      | Prompt interactively for any missing values and run the CRN picker             |
+| `--help`                 | Show this message and exit                                                     |
+
+```bash
+# Create a basic instance with a size slug
+aleph instance create web \
+  --image ubuntu24 \
+  --size 1vcpu-2gb \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
+
+# Create a GPU instance
+aleph instance create gpu-job \
+  --image ubuntu24 \
+  --gpu h100 \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
+
+# Create with custom resources and a persistent volume
+aleph instance create db \
+  --image ubuntu24 \
+  --size 4vcpu-8gb \
+  --persistent-volume name=data,mount=/data,size=100GB \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
+
+# Create with interactive prompts for everything else
+aleph instance create -i web
+```
+
+## Deleting an Instance
+
+Forget an INSTANCE message (send a FORGET) and stop billing. This command **only** sends the FORGET - it does **not** erase the VM's data on the CRN, remove port forwards, or stop any Superfluid payment flow.
+
+For a full teardown, run `aleph instance erase` first to wipe the VM's data on the CRN, then `aleph instance delete` to forget the message and stop billing. Remove port forwards separately with `aleph instance port-forward delete` if needed.
+
+### Usage
+
+```bash
+aleph instance delete [OPTIONS] <VM_ID>
 ```
 
 #### Arguments
 
-| Argument    | Type      | Description                  |
-| ----------- | --------- | ---------------------------- |
-| `ITEM_HASH` | ITEM HASH | Instance item hash to forget |
+| Argument | Description               |
+|----------|---------------------------|
+| `VM_ID`  | Instance item hash        |
 
 #### Options
 
-| Options                                | Type                                                                                                                                             | Description                                                                                                                                                   |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--reason`                             | TEXT                                                                                                                                             | Reason for deleting the instance [default: User deletion]                                                                                                     |
-| `--chain`                              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance                                                                                                                  |
-| `--domain`                             | TEXT                                                                                                                                             | Domain of the CRN where an associated VM is running. It ensures your VM will be stopped and erased on the CRN before the instance message is actually deleted |
-| `--private-key`                        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                                                                                      |
-| `--private-key-file`                   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                                                                      |
-| `--print-message / --no-print-message` |                                                                                                                                                  | Print the message after deletion [default: no-print-message]                                                                                                  |
-| `--debug / --no-debug`                 |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                                                                                      |
-| `--help`                               |                                                                                                                                                  | Show this message and exit                                                                                                                                    |
+| Option                | Description                                              |
+|-----------------------|----------------------------------------------------------|
+| `--reason <REASON>`   | Reason recorded on the FORGET message [default: "User deletion"] |
+| `-y, --yes`           | Skip the confirmation prompt                             |
+| `--json`              | Output results as JSON                                   |
+| `--account <ACCOUNT>` | Named account (defaults to the active account)           |
+| `--private-key <KEY>` | Hex-encoded private key                                  |
+| `--chain <CHAIN>`     | Signing chain                                            |
+| `--dry-run`           | Build and sign the message but don't submit it           |
+| `--help`              | Show this message and exit                               |
 
 ```bash
-# Delete an instance
+# Typical teardown: erase VM data first, then forget the message
+aleph instance erase ITEM_HASH
 aleph instance delete ITEM_HASH
+
+# Delete with a reason
+aleph instance delete ITEM_HASH --reason "decommission"
+
+# Skip confirmation prompt
+aleph instance delete ITEM_HASH -y
 ```
 
 ## Listing Instances
 
-List all instances associated to an account
+List all instances associated with an account.
 
 ### Usage
 
@@ -197,374 +154,224 @@ aleph instance list [OPTIONS]
 
 #### Options
 
-| Options                | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--address`            | TEXT                                                                                                                                             | Owner address of the instances                                                           |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance                                             |
-| `--json / --no-json`   |                                                                                                                                                  | Print as json instead of rich table [default: no-json]                                   |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
+| Option              | Description                                        |
+|---------------------|----------------------------------------------------|
+| `--address <ADDR>`  | Owner address to list instances for                |
+| `--json`            | Output results as JSON                             |
+| `--account <NAME>`  | Named account (defaults to the active account)     |
+| `--private-key <K>` | Hex-encoded private key                            |
+| `--help`            | Show this message and exit                         |
 
 ```bash
-# Listing your instances
+# List your own instances
 aleph instance list
 
-# Listing ADDRESS instances as json
+# List instances for a specific address as JSON
 aleph instance list --address ADDRESS --json
 ```
 
-## Rebooting an instance
+## Rebooting an Instance
 
-Reboot an instance
+Reboot a VM instance.
 
 ### Usage
 
 ```bash
-aleph instance reboot [OPTIONS] VM_ID
+aleph instance reboot [OPTIONS] <VM_ID>
 ```
 
-##### Arguments
+#### Arguments
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to reboot |
-
-#### Options
-
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the VM is running |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Argument | Description                |
+|----------|----------------------------|
+| `VM_ID`  | VM instance item hash      |
 
 ```bash
 # Reboot an instance
 aleph instance reboot VM_ID
 ```
 
-## Allocate an instance
+## Starting an Instance
 
-Notify a CRN to start an instance (for Pay-As-You-Go and confidential instances only)
-
-### Usage
-
-```bash
-aleph instance allocate [OPTIONS] VM_ID
-```
-
-#### Arguments
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to allocate |
-
-#### Options
-
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the VM will be allocated |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
-
-```bash
-# Allocating an instance
-aleph instance allocate VM_ID
-```
-
-## Check instance logs
-
-Retrieve the logs of an instance
+Start (allocate) a VM instance on the CRN. This replaces the old `allocate` command.
 
 ### Usage
 
 ```bash
-aleph instance logs [OPTIONS] VM_ID
+aleph instance start [OPTIONS] <VM_ID>
 ```
 
 #### Arguments
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to retrieve the logs from |
+| Argument | Description                                                   |
+|----------|---------------------------------------------------------------|
+| `VM_ID`  | VM instance item hash (accepts a unique prefix)               |
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the VM is running |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Option                  | Description                                                                       |
+|-------------------------|-----------------------------------------------------------------------------------|
+| `--crn-url <URL>`       | CRN endpoint URL override (bypasses scheduler discovery)                          |
+| `--json`                | Output results as JSON                                                            |
+| `--account <ACCOUNT>`   | Named account (defaults to the active account)                                    |
+| `--private-key <KEY>`   | Hex-encoded private key                                                           |
+| `--chain <CHAIN>`       | Signing chain                                                                     |
+| `--dry-run`             | Build and sign the message but don't submit it                                    |
+| `--help`                | Show this message and exit                                                        |
 
 ```bash
-# Retrieve logs of an instance
-aleph instance logs VM_ID
+# Start an instance
+aleph instance start VM_ID
 ```
 
-## Stop an instance
+## Stopping an Instance
+
+Stop a running VM instance.
 
 ### Usage
 
 ```bash
-aleph instance stop [OPTIONS] VM_ID
+aleph instance stop [OPTIONS] <VM_ID>
 ```
-
-#### Arguments
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to stop |
-
-#### Options
-
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the VM is running |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
 
 ```bash
 # Stop an instance
 aleph instance stop VM_ID
 ```
 
-## Initialize a Confidential Communication
+## Confidential Instances
 
-Initialize a confidential communication session with the VM
+The confidential VM workflow lives under `aleph instance confidential` (subcommands: `init-session`, `start`, `create`). Use `aleph instance create --confidential` to allocate a confidential VM without the full attestation flow, or `aleph instance confidential create` for the all-in-one (create, allocate, init session, start). See the [confidential instances guide](/devhub/compute-resources/confidential-instances/01-confidential-instance-introduction) for the full deployment workflow.
 
-### Usage
+## Show Instance Details
 
-```bash
-aleph instance confidential-init-session [OPTIONS] VM_ID
-```
-
-#### Arguments
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to initialize the session for |
-
-#### Options
-
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the session will be initialized |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--policy` | INTEGER | Policy for the confidential session [default: 1] |
-| `--keep-session / --no-keep-session` |  | Keeping the already initiated session |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
-
-```bash
-# Starting a confidential communication with a VM
-aleph instance confidential-init-session VM_ID
-```
-
-## Start a Confidential Instance
-
-Validate the authenticity of the VM and start it. This command should be run after `confidential-init-session`.
+Show details of a single VM instance: INSTANCE message from the CCN, scheduler placement, and status. Pass `--verbose` to also fetch live networking information from the CRN.
 
 ### Usage
 
 ```bash
-aleph instance confidential-start [OPTIONS] VM_ID
+aleph instance show [OPTIONS] <VM_ID>
 ```
-
-#### Arguments
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `VM_ID` | TEXT | VM item hash to start |
 
 #### Options
 
-| Options | Type | Description |
-|---------|------|-------------|
-| `--domain` | TEXT | CRN domain on which the VM will be started |
-| `--chain` | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using to pay for your instance |
-| `--firmware-hash` | TEXT | Hash of the UEFI Firmware content, to validate measure (ignored if path is provided) [default: 89b76b0e64fe9015084fbffdf8ac98185bafc688bfe7a0b398585c392d03c7ee] |
-| `--firmware-file` | TEXT | Path to the UEFI Firmware content, to validate measure (instead of the hash) |
-| `--vm-secret` | TEXT | Secret password to start the VM |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--verbose / --no-verbose` |  | Display additional information [default: verbose] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Option              | Description                                                                |
+|---------------------|----------------------------------------------------------------------------|
+| `-v, --verbose`     | Also reach the CRN for live networking (IPv4/IPv6, mapped host ports)      |
+| `--json`            | Output results as JSON                                                     |
+| `--help`            | Show this message and exit                                                 |
 
 ```bash
-# Start a confidential VM after initializing the session
-aleph instance confidential-start VM_ID
+# Show instance details
+aleph instance show a41fb91c3e68
 
-# Start with a custom firmware file for validation
-aleph instance confidential-start VM_ID --firmware-file /path/to/firmware.bin
+# Show with live networking info
+aleph instance show a41fb91c3e68 --verbose
+
+# Show as JSON
+aleph instance show a41fb91c3e68 --json
 ```
 
-## Launching a Confidential Instance
+## SSH Into an Instance
 
-Create (optional), start and unlock a confidential VM (all-in-one command)
-
-This command combines the following commands:
-
-```
-- create (unless vm_id is passed)
-- allocate
-- confidential-init-session
-- confidential-start
-```
+Open an SSH session to a dispatched VM instance. The scheduler is queried to find the CRN, then the VM's IPv6 address is discovered from the CRN.
 
 ### Usage
 
 ```bash
-aleph instance confidential [OPTIONS] [VM_ID]
+aleph instance ssh [OPTIONS] <VM_ID> [SSH_ARGS]...
 ```
-
-#### Arguments
-
-| Argument | Type  | Description                                                                          |
-| -------- | ----- | ------------------------------------------------------------------------------------ |
-| `VM_ID`  | VM ID | Item hash of your VM. If provided, skip the instance creation, else create a new one |
 
 #### Options
 
-| **Option** | **Type** | **Description** |
-|------------|----------|-----------------|
-| `--crn-url` | TEXT | URL of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--crn-hash` | TEXT | Hash of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--policy` | INTEGER | Policy for the confidential session [default: 1] |
-| `--confidential-firmware` | TEXT | Hash to UEFI Firmware to launch confidential instance [default: ba5bb13f3abca960b101a759be162b229e2b7e93ecad9d1307e54de887f177ff] |
-| `--firmware-hash` | TEXT | Hash of the UEFI Firmware content, to validate measure (ignored if path is provided) [default: 89b76b0e64fe9015084fbffdf8ac98185bafc688bfe7a0b398585c392d03c7ee] |
-| `--firmware-file` | TEXT | Path to the UEFI Firmware content, to validate measure (instead of the hash) |
-| `--keep-session / --no-keep-session` | FLAG | Keeping the already initiated session |
-| `--vm-secret` | TEXT | Secret password to start the VM |
-| `--payment-type` | [hold, superfluid, credit, nft] | Payment method: holding tokens, credits, NFTs, or Pay-As-You-Go via token streaming |
-| `--payment-chain` | [AVAX, BASE, ETH, SOL] | Chain you want to use to pay for your instance |
-| `--name` | TEXT | Name of your new instance |
-| `--rootfs` | TEXT | Hash of the rootfs to use for your instance. Defaults to Ubuntu 22. You can also create your own rootfs and pin it |
-| `--compute-units` | INTEGER | Number of compute units to allocate. Compute units correspond to a tier that includes vcpus, memory, disk and gpu presets. For reference, run: aleph pricing --help |
-| `--vcpus` | INTEGER | Number of virtual CPUs to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides vCPUs only |
-| `--memory` | INTEGER | Maximum memory (RAM) in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides memory only |
-| `--rootfs-size` | INTEGER RANGE | Main VM partition size in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides disk only [x<=1953125] |
-| `--timeout-seconds` | FLOAT | If vm is not called after [timeout_seconds] it will shutdown [default: 30.0] |
-| `--ssh-pubkey-file` | PATH | Path to a public ssh key to be added to the instance [default: /home/$USER/.ssh/id_rsa.pub] |
-| `--address` | TEXT | Address of the payer. In order to delegate the payment, your account must be authorized beforehand to publish on the behalf of this address. See the docs for more info: https://docs.aleph.cloud/protocol/permissions/ |
-| `--gpu / --no-gpu` | FLAG | Launch an instance attaching a GPU to it [default: no-gpu] |
-| `--premium / --no-premium` | FLAG | Use Premium GPUs (VRAM > 48GiB) |
-| `--skip-volume / --no-skip-volume` | FLAG | Skip prompt to attach more volumes [default: no-skip-volume] |
-| `--persistent-volume` | TEXT | Persistent volumes are allocated on the host machine and are not deleted when the VM is stopped. Requires at least name, mount path, and size_mib. To add multiple, reuse the same argument. Example: --persistent-volume name=data,mount=/opt/data,size_mib=1000. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/persistent/ |
-| `--ephemeral-volume` | TEXT | Ephemeral volumes are allocated on the host machine when the VM is started and deleted when the VM is stopped. Requires at least mount path and size_mib. To add multiple, reuse the same argument. Example: --ephemeral-volume mount=/opt/tmp,size_mib=100 |
-| `--immutable-volume` | TEXT | Immutable volumes are pinned on the network and can be used by multiple VMs at the same time. They are read-only and useful for setting up libraries or other dependencies. Requires at least mount path and ref (volume message hash). use_latest is True by default, to use the latest version of the volume, if it has been amended. To add multiple, reuse the same argument. Example: --immutable-volume mount=/opt/packages,ref=25a3...8d94. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/immutable/ |
-| `--crn-auto-tac / --no-crn-auto-tac` | FLAG | Automatically accept the Terms & Conditions of the CRN if you read them beforehand [default: no-crn-auto-tac] |
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` | FLAG | Enable debug logging [default: no-debug] |
-| `--help` | FLAG | Show this message and exit |
+| Option                  | Description                                               |
+|-------------------------|-----------------------------------------------------------|
+| `--crn-url <URL>`       | Skip scheduler discovery and connect directly             |
+| `--user <USER>`         | SSH user to connect as [default: root]                    |
+| `--port <PORT>`         | SSH port [default: 22]                                    |
+| `--identity <PATH>`     | Path to an SSH private key (`ssh -i`)                     |
+| `--json`                | Output results as JSON                                    |
+| `--help`                | Show this message and exit                                |
 
 ```bash
-# Create a basic confidential VM with default settings
-aleph instance confidential \
-  --name secure-vm \
-  --payment-type hold \
-  --payment-chain ETH
+# SSH into an instance
+aleph instance ssh <vm-hash>
 
-# Create a confidential VM using a CRN and keep the session alive
-aleph instance confidential \
-  --name confidential-db \
-  --crn-url https://example.com/my-crn \
-  --crn-hash 123abc456def \
-  --keep-session \
-  --payment-type superfluid \
-  --payment-chain BASE
+# SSH as a specific user with a key
+aleph instance ssh <vm-hash> --user ubuntu --identity ~/.ssh/id_ed25519
 
-# Convert an existing instance to a confidential one
-aleph instance confidential VM_HASH
-
-# Create a confidential VM with a persistent volume and a VM startup secret
-aleph instance confidential \
-  --name private-ai-node \
-  --vm-secret mySecret \
-  --persistent-volume name=ai_data,mount=/data,size_mib=8000 \
-  --payment-type nft \
-  --payment-chain SOL
+# Run a remote command
+aleph instance ssh <vm-hash> -- uptime
 ```
 
-## Create a GPU Instance
+## Erasing Instance Data
+
+Erase a VM instance's data on the CRN (does not delete the INSTANCE message).
 
 ### Usage
 
 ```bash
-aleph instance gpu [OPTIONS]
+aleph instance erase [OPTIONS] <VM_ID>
 ```
 
-#### Options
+```bash
+# Erase instance data on the CRN
+aleph instance erase VM_ID
+```
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `--payment-chain` | [AVAX, BASE] | Chain you want to use to pay for your instance |
-| `--name` | TEXT | Name of your new instance |
-| `--rootfs` | TEXT | Hash of the rootfs to use for your instance. Defaults to Ubuntu 22. You can also create your own rootfs and pin it |
-| `--compute-units` | INTEGER | Number of compute units to allocate. Compute units correspond to a tier that includes vcpus, memory, disk and gpu presets. For reference, run: aleph pricing --help |
-| `--vcpus` | INTEGER | Number of virtual CPUs to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides vCPUs only |
-| `--memory` | INTEGER | Maximum memory (RAM) in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides memory only |
-| `--rootfs-size` | INTEGER RANGE | Main VM partition size in MiB to allocate. Set to 0 to use the value from COMPUTE_UNITS. Overrides disk only [x<=1953125] |
-| `--premium / --no-premium` |  | Use Premium GPUs (VRAM > 48GiB) |
-| `--timeout-seconds` | FLOAT | If vm is not called after [timeout_seconds] it will shutdown [default: 30.0] |
-| `--ssh-pubkey-file` | PATH | Path to a public ssh key to be added to the instance [default: /home/$USER/.ssh/id_rsa.pub] |
-| `--address` | TEXT | Address of the payer. In order to delegate the payment, your account must be authorized beforehand to publish on the behalf of this address. See the docs for more info: https://docs.aleph.cloud/protocol/permissions/ |
-| `--crn-hash` | TEXT | Hash of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--crn-url` | TEXT | URL of the CRN to deploy to (only applicable for confidential and/or Pay-As-You-Go instances) |
-| `--skip-volume / --no-skip-volume` |  | Skip prompt to attach more volumes [default: no-skip-volume] |
-| `--persistent-volume` | TEXT | Persistent volumes are allocated on the host machine and are not deleted when the VM is stopped. Requires at least name, mount path, and size_mib. To add multiple, reuse the same argument. Example: --persistent-volume name=data,mount=/opt/data,size_mib=1000. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/persistent/ |
-| `--ephemeral-volume` | TEXT | Ephemeral volumes are allocated on the host machine when the VM is started and deleted when the VM is stopped. Requires at least mount path and size_mib. To add multiple, reuse the same argument. Example: --ephemeral-volume mount=/opt/tmp,size_mib=100 |
-| `--immutable-volume` | TEXT | Immutable volumes are pinned on the network and can be used by multiple VMs at the same time. They are read-only and useful for setting up libraries or other dependencies. Requires at least mount path and ref (volume message hash). use_latest is True by default, to use the latest version of the volume, if it has been amended. To add multiple, reuse the same argument. Example: --immutable-volume mount=/opt/packages,ref=25a3...8d94. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/immutable/ |
-| `--crn-auto-tac / --no-crn-auto-tac` |  | Automatically accept the Terms & Conditions of the CRN if you read them beforehand [default: no-crn-auto-tac] |
-| `--channel` | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key` | TEXT | Your private key. Cannot be used with --private-key-file |
-| `--private-key-file` | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |  | Print the message after creation [default: no-print-message] |
-| `--verbose / --no-verbose` |  | Display additional information [default: verbose] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+## Instance Pricing
+
+Show pricing for an instance configuration. See the [pricing page](./pricing.md) for full details.
 
 ```bash
-# Create a basic GPU instance with default settings (Ubuntu rootfs, minimal resources)
-aleph instance gpu \
-  --name basic-gpu \
-  --payment-chain AVAX
+# Price by size slug
+aleph instance price --size 4vcpu-8gb
 
-# Create a GPU instance with custom CPU/RAM and a pinned rootfs
-aleph instance gpu \
-  --name custom-gpu \
-  --vcpus 8 \
-  --memory 16384 \
-  --rootfs RootfsHash \
-  --payment-chain BASE
+# Price a GPU instance
+aleph instance price --gpu h100
 
-# Create a premium GPU instance and a specific CRN
-aleph instance gpu \
-  --name full-stack-gpu \
-  --vcpus 12 \
-  --memory 32768 \
-  --rootfs-size 30000 \
-  --cN_HASH \
-  --premium \rn-url CRN_URL \
-  --crn-hash CR
-  --payment-chain AVAX
+# List available GPU models
+aleph instance price --list-gpus
+```
+
+## Instance Backups
+
+Manage VM backups: create, inspect, download, delete, or restore.
+
+### Usage
+
+```bash
+aleph instance backup [OPTIONS] <COMMAND>
+```
+
+| Subcommand  | Description                                       |
+|-------------|---------------------------------------------------|
+| `create`    | Create a backup of a running VM                   |
+| `info`      | Show the latest backup status for a VM            |
+| `download`  | Download a backup archive to disk                 |
+| `delete`    | Delete a backup                                   |
+| `restore`   | Restore a VM from a local QCOW2 file or a volume  |
+
+```bash
+# Create a backup of a running instance
+aleph instance backup create VM_ID
+```
+
+## Port Forwarding
+
+Manage TCP/UDP port forwards for VM instances. The command is `port-forward` (alias: `pfw`).
+
+For detailed documentation, see the [port-forward documentation](port-forwarder.md).
+
+```bash
+# List port forwards for your account
+aleph instance port-forward list
+
+# Create a TCP port forward for port 80
+aleph instance port-forward create YOUR_INSTANCE_HASH 80
+
+# Delete a port forward
+aleph instance port-forward delete YOUR_INSTANCE_HASH --port 80
 ```
 
 ## Troubleshooting
@@ -574,8 +381,4 @@ Common issues and solutions:
 - **Instance not starting**: Check resource allocation and system compatibility
 - **SSH connection failures**: Verify your SSH key was properly added and the instance is running
 - **Performance issues**: Consider increasing CPU, memory, or using a GPU instance
-- **Payment errors**: Ensure you have sufficient ALEPH tokens for staking or PAYG balance
-
-## Related Commands
-
-For detailed documentation on port forwarding functionality, see the [port-forwarder documentation](port-forwarder.md).
+- **Payment errors**: Ensure you have sufficient credits or ALEPH tokens

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/message.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/message.md
@@ -1,255 +1,208 @@
 # Message Management
 
+The `message` command group allows you to query, sync, and forget raw protocol messages on the Aleph Cloud network.
+
+> **Note:** Creating and amending posts now lives under `aleph post` (see the post command). Message signing and watching have no direct CLI equivalent in the Rust CLI.
+
 ## Overall Usage
 
 ```bash
-aleph message [OPTIONS] KEY_COMMAND [ARGS]...
+aleph message [OPTIONS] COMMAND [ARGS]...
 ```
 
 ### Options
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Option   | Description                |
+| -------- | -------------------------- |
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ### Key Commands
 
 | Command  | Description                                    |
 | -------- | ---------------------------------------------- |
-| `get`    | Retrieve a message from Aleph Cloud            |
-| `find`   | Search for messages on Aleph Cloud             |
-| `post`   | Post a message on Aleph Cloud                  |
-| `amend`  | Amend an existing Aleph Cloud message          |
-| `forget` | Forget an existing Aleph Cloud message         |
-| `watch`  | Watch a hash for amends and print amend hashes |
-| `sign`   | Sign an aleph message with a private key       |
+| `get`    | Get a message by its item hash                 |
+| `list`   | List messages (with filters)                   |
+| `forget` | Forget messages or entire aggregates           |
+| `retry`  | Re-submit a previously rejected message        |
+| `sync`   | Sync messages from one node to another         |
 
 ## Get a Message
 
-Retrieve a message from Aleph Cloud
+Get a message by its item hash.
 
 ### Usage
 
 ```bash
-aleph message get [OPTIONS] ITEM_HASH
+aleph message get [OPTIONS] <ITEM_HASH>
 ```
 
 #### Arguments
 
-| Argument    | Type | Description              |
-| ----------- | ---- | ------------------------ |
-| `ITEM_HASH` | TEXT | Item hash of the message |
+| Argument    | Description              |
+| ----------- | ------------------------ |
+| `ITEM_HASH` | The item hash of the message to fetch |
 
 #### Options
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Option   | Description                |
+| -------- | -------------------------- |
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ```bash
 # Retrieve a message
 aleph message get ITEM_HASH
 ```
 
-## Find a Message
+## List Messages
 
-Search for messages on Aleph Cloud
-
-### Usage
-
-```bash
-aleph message find [OPTIONS]
-```
-
-#### Options
-
-| Option                                                     | Type                                                | Description                                                                                     |
-| ---------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `--pagination`                                             | INTEGER                                             | The maximum number of messages to return [default: 200]                                         |
-| `--page`                                                   | INTEGER                                             | The page number to display [default: 1]                                                         |
-| `--message-types`                                          | [post, aggregate, store, program, instance, forget] | Types of messages to search for, separated by commas                                            |
-| `--content-types`                                          | TEXT                                                | Content types to search for, separated by commas                                                |
-| `--content-keys`                                           | TEXT                                                | Specific content keys to search for, separated by commas                                        |
-| `--refs`                                                   | TEXT                                                | References of messages to search for, separated by commas                                       |
-| `--addresses`                                              | TEXT                                                | Sender addresses to search for, separated by commas                                             |
-| `--tags`                                                   | TEXT                                                | Tags associated with the messages to search for, separated by commas                            |
-| `--hashes`                                                 | TEXT                                                | Hashes of the messages to search for, separated by commas                                       |
-| `--channels`                                               | TEXT                                                | Channels associated with the messages to search for, separated by commas                        |
-| `--chains`                                                 | TEXT                                                | Blockchain chains associated with the messages to search for, separated by commas               |
-| `--start-date`                                             | TEXT                                                | Start date for the message search (format: `YYYY-MM-DD`)                                        |
-| `--end-date`                                               | TEXT                                                | End date for the message search (format: `YYYY-MM-DD`)                                          |
-| `--ignore-invalid-messages / --no-ignore-invalid-messages` |                                                     | If enabled, ignores invalid messages in the search results [default: `ignore-invalid-messages`] |
-| `--help`                                                   |                                                     | Show this message and exit                                                                      |
-
-```bash
-# Search for messages from several addresses
-aleph message find --adresses ADDRESS_1,ADDRESS_2,ADDRESS_3
-
-# Search for messages with specific tags
-aleph message find --tags TAG_1,TAG_2
-
-# Search for messages with pagination
-aleph message find --pagination 50 --page 1
-```
-
-## Post a Message
-
-Post a message on Aleph Cloud
+List messages with optional filters. Walks cursor pagination server-side.
 
 ### Usage
 
 ```bash
-aleph message post [OPTIONS]
+aleph message list [OPTIONS]
 ```
 
 #### Options
 
-| Option                 | Type | Description                                                                                             |
-| ---------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| `--path`               | PATH | Path to the content you want to post. If omitted, you can input your content directly inside the prompt |
-| `--type`               | TEXT | Text representing the message object type [default: test]                                               |
-| `--ref`                | TEXT | Item hash of the message to update                                                                      |
-| `--channel`            | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                                |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                |
-| `--debug / --no-debug` |      | [default: no-debug]                                                                                     |
-| `--help`               |      | Show this message and exit                                                                              |
+| Option                      | Description                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| `--count <N>`               | Maximum number of messages to return [default: 200]                                            |
+| `--message-type <TYPE>`     | Filter by message type: `aggregate`, `forget`, `instance`, `program`, `post`, `store`          |
+| `--message-types <TYPES>`   | Filter by multiple message types (CSV or repeated)                                             |
+| `--content-types <TYPES>`   | Filter by content types (CSV or repeated)                                                      |
+| `--content-keys <KEYS>`     | Filter by content keys (CSV or repeated)                                                       |
+| `--addresses <ADDRS>`       | Sender addresses (CSV or repeated)                                                             |
+| `--owners <ADDRS>`          | Content owners (CSV or repeated)                                                               |
+| `--tags <TAGS>`             | Tags (CSV or repeated)                                                                         |
+| `--hashes <HASHES>`         | Specific item hashes (CSV or repeated)                                                         |
+| `--channels <CHANNELS>`     | Channels (CSV or repeated)                                                                     |
+| `--chains <CHAINS>`         | Sender chains (CSV or repeated)                                                                |
+| `--start-date <DATE>`       | Earliest date (RFC3339 or unix seconds)                                                        |
+| `--end-date <DATE>`         | Latest date (RFC3339 or unix seconds)                                                          |
+| `--sort-by <KEY>`           | Sort key: `time` or `tx-time`                                                                  |
+| `--sort-order <ORDER>`      | Sort order: `asc` or `desc`                                                                    |
+| `--message-statuses <S>`    | Message statuses (CSV or repeated): `pending`, `processed`, `removing`, `removed`, `forgotten` |
+| `--json`                    | Output results as JSON                                                                         |
+| `--help`                    | Show this message and exit                                                                     |
 
 ```bash
-# Post a message by giving the path of the message
-aleph message post --path PATH
+# List messages from several addresses
+aleph message list --addresses ADDRESS_1,ADDRESS_2,ADDRESS_3
 
-# Post a new message from a file on a specific channel
-aleph message post --path PATH --channel "MY_CHANNEL"
+# List messages with specific tags
+aleph message list --tags TAG_1,TAG_2
 
-# Update a post with the prompt
-aleph message post --ref REF
-```
-
-## Amend a Message
-
-Amend an existing Aleph Cloud message
-
-### Usage
-
-```bash
-aleph message amend [OPTIONS] ITEM_HASH
-```
-
-#### Arguments
-
-| Argument    | Type | Description                            |
-| ----------- | ---- | -------------------------------------- |
-| `ITEM_HASH` | TEXT | Hash reference of the message to amend |
-
-#### Options
-
-| Option                 | Type | Description                                                                              |
-| ---------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |      | [default: no-debug]                                                                      |
-| `--help`               |      | Show this message and exit                                                               |
-
-```bash
-# Amend a message without a private key file
-aleph message amend ITEM_HASH
-
-# Amend an existing message using its item hash
-aleph message amend ITEM_HASH --private-key PATH
+# List up to 50 STORE messages
+aleph message list --count 50 --message-type store
 ```
 
 ## Forget a Message
 
-Forget an existing Aleph Cloud message
+Forget messages on the network. Forget by individual item hashes, or use `--aggregates` to tombstone an entire aggregate.
 
 ### Usage
 
 ```bash
-aleph message forget [OPTIONS] HASHES
+aleph message forget [OPTIONS] [HASHES]...
 ```
 
 #### Arguments
 
-| Argument | Type | Description                                                   |
-| -------- | ---- | ------------------------------------------------------------- |
-| `HASHES` | TEXT | Comma separated list of hash references of messages to forget |
+| Argument    | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `HASHES...` | Item hashes of the messages to forget (one per hash) |
 
 #### Options
 
-| Option                 | Type | Description                                                                                             |
-| ---------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| `--reason`             | TEXT | A description of why the messages are being forgotten                                                   |
-| `--channel`            | TEXT | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS] |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                                |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                |
-| `--debug / --no-debug` |      | [default: no-debug]                                                                                     |
-| `--help`               |      | Show this message and exit                                                                              |
+| Option                      | Description                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `--aggregates <HASHES>`     | Item hashes identifying aggregates to forget entirely (all elements with the same sender + key) |
+| `--reason <REASON>`         | Reason for forgetting                                                                      |
+| `--channel <CHANNEL>`       | Channel name                                                                               |
+| `--on-behalf-of <ADDR>`     | Sign on behalf of another address (requires authorization)                                 |
+| `-y, --yes`                 | Skip the confirmation prompt and submit immediately                                        |
+| `--json`                    | Output results as JSON                                                                     |
+| `--account <ACCOUNT>`       | Named account (defaults to the active account)                                             |
+| `--private-key <KEY>`       | Hex-encoded private key                                                                    |
+| `--chain <CHAIN>`           | Signing chain                                                                              |
+| `--dry-run`                 | Build and sign the message but don't submit it                                             |
+| `--help`                    | Show this message and exit                                                                 |
 
 ```bash
-# Forget a message by its hash
-aleph message forget ITEM_HASH --reason Outdated content
+# Forget two specific messages
+aleph message forget abc123... def456...
 
-# Forget multiple messages by their hashes
-aleph message forget ITEM_HASH_1,ITEM_HASH_2 --reason Incorrect info
+# Forget the entire aggregate keyed at the (sender, key) of this element
+aleph message forget --aggregates abc123...
+
+# Forget with a reason
+aleph message forget ITEM_HASH --reason "Outdated content"
 ```
 
-## Watch a Message
+## Retry a Message
 
-Watch a hash for amends and print amend hashes
+Re-submit a previously rejected message.
 
 ### Usage
 
 ```bash
-aleph message watch [OPTIONS] REF
+aleph message retry [OPTIONS] <ITEM_HASH>
 ```
 
 #### Arguments
 
-| Argument | Type | Description                            |
-| -------- | ---- | -------------------------------------- |
-| `REF`    | TEXT | Hash reference of the message to watch |
+| Argument    | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `ITEM_HASH` | The item hash of the rejected message to re-submit |
 
 #### Options
 
-| Option                 | Type    | Description                |
-| ---------------------- | ------- | -------------------------- |
-| `--indent`             | INTEGER | Number of indents to use   |
-| `--debug / --no-debug` |         | [default: no-debug]        |
-| `--help`               |         | Show this message and exit |
+| Option      | Description                                         |
+| ----------- | --------------------------------------------------- |
+| `--dry-run` | Print the reconstructed envelope without submitting |
+| `--json`    | Output results as JSON                              |
+| `--help`    | Show this message and exit                          |
 
 ```bash
-# Watch a message
-aleph message watch REF
-
-# Watch a message with indentation
-aleph message watch REF --indent 2
+# Retry a rejected message
+aleph message retry ITEM_HASH
 ```
 
-## Sign a Message
+## Sync Messages
 
-Sign a message that will be post on aleph
+Sync messages from one node to another. Fetches messages from the source and POSTs any missing ones to the target.
 
 ### Usage
 
 ```bash
-aleph message sign [OPTIONS]
+aleph message sync [OPTIONS] --source <SOURCE> --target <TARGET>
 ```
 
 #### Options
 
-| Option                 | Type | Description                                                                              |
-| ---------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--message`            | TEXT | Message to sign                                                                          |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--debug / --no-debug` |      | [default: no-debug]                                                                      |
-| `--help`               |      | Show this message and exit                                                               |
+| Option                  | Description                                                        |
+|-------------------------|--------------------------------------------------------------------|
+| `--source <URL>`        | URL of the source node (messages are fetched from here)            |
+| `--target <URL>`        | URL of the target node (missing messages are POSTed here)          |
+| `--count <N>`           | Maximum number of messages to fetch from each node [default: 200]  |
+| `--dry-run`             | Show what would be synced without actually POSTing                 |
+| `--message-type <TYPE>` | Filter by message type                                             |
+| `--addresses <ADDRS>`   | Sender addresses (CSV or repeated)                                 |
+| `--json`                | Output results as JSON                                             |
+| `--help`                | Show this message and exit                                         |
 
 ```bash
-# Sign a message using the prompt
-aleph message sign
+# Sync messages between two nodes
+aleph message sync \
+  --source https://api1.aleph.cloud \
+  --target https://api2.aleph.cloud
 
-# Sign a message with a private key without the prompt
-aleph message sign --message MESSAGE --private-key PATH
+# Dry-run to preview what would be synced
+aleph message sync \
+  --source https://api1.aleph.cloud \
+  --target https://api2.aleph.cloud \
+  --dry-run
 ```

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/node.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/node.md
@@ -1,5 +1,7 @@
 # Node Management
 
+The `node` command group allows you to list, register, stake, and manage network nodes on the Aleph Cloud network. For node registration and staking, see `aleph node --help`.
+
 ## Overall Usage
 
 ```bash
@@ -8,80 +10,62 @@ aleph node [OPTIONS] COMMAND [ARGS]...
 
 ### Options
 
-| Option   | Type | Description                |
-| -------- | ---- | -------------------------- |
-| `--help` |      | Show this message and exit |
+| Option   | Description                |
+| -------- | -------------------------- |
+| `--json` | Output results as JSON     |
+| `--help` | Show this message and exit |
 
 ### Key Commands
 
-| Command   | Description                                  |
-| --------- | -------------------------------------------- |
-| `compute` | Get all compute nodes (CRN) on aleph network |
-| `core`    | Get all core nodes (CCN) on aleph network    |
+| Command      | Description                                  |
+| ------------ | -------------------------------------------- |
+| `list`       | List nodes on the network                    |
+| `create-ccn` | Register a new Core Channel Node (CCN)        |
+| `create-crn` | Register a new Compute Resource Node (CRN)    |
+| `amend`      | Amend metadata fields on an existing node     |
+| `stake`      | Stake ALEPH tokens on a node                 |
+| `unstake`    | Remove your stake from a node                |
+| `link`       | Link a CRN to one of your CCNs               |
+| `unlink`     | Unlink a CRN from your CCN                   |
+| `drop`       | Remove a node from the network               |
 
-## Get All Compute Nodes
+## List Nodes
 
-Get all compute nodes (CRN) on aleph network
-
-### Usage
-
-```bash
-aleph node compute [OPTIONS]
-```
-
-#### Options
-
-| Option                   | Type | Description                                              |
-| ------------------------ | ---- | -------------------------------------------------------- |
-| `--json / --no-json`     |      | Print as JSON instead of a rich table [default: no-json] |
-| `--active / --no-active` |      | Only show active nodes [default: no-active]              |
-| `--address`              | TEXT | Owner address to filter by                               |
-| `--payg-receiver`        | TEXT | PAYG (Pay-As-You-Go) receiver address to filter by       |
-| `--crn-url`              | TEXT | CRN URL to filter by                                     |
-| `--crn-hash`             | TEXT | CRN hash to filter by                                    |
-| `--ccn-hash`             | TEXT | CCN hash to filter by                                    |
-| `--debug / --no-debug`   |      | Enable debug logging [default: no-debug]                 |
-| `--help`                 |      | Show this message and exit                               |
-
-```bash
-# Get all compute nodes in JSON format
-aleph node compute --json
-
-# Get only active compute nodes
-aleph node compute --active
-
-# Get compute nodes filtered by address
-aleph node compute --address ADDRESS
-```
-
-## Get All Core Nodes
-
-Get all core nodes (CCN) on aleph network
+List nodes on the network. Use `--type` to filter by node type.
 
 ### Usage
 
 ```bash
-aleph node core [OPTIONS]
+aleph node list [OPTIONS]
 ```
 
 #### Options
 
-| Option                   | Type | Description                                              |
-| ------------------------ | ---- | -------------------------------------------------------- |
-| `--json / --no-json`     |      | Print as JSON instead of a rich table [default: no-json] |
-| `--active / --no-active` |      | Only show active nodes [default: no-active]              |
-| `--address`              | TEXT | Owner address to filter by                               |
-| `--ccn-hash`             | TEXT | CCN hash to filter by                                    |
-| `--debug / --no-debug`   |      | Enable debug logging [default: no-debug]                 |
-| `--help`                 |      | Show this message and exit                               |
+| Option                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `--type <TYPE>`                 | Filter by node type: `ccn` (Core Channel Node) or `crn` (Compute Resource Node) |
+| `--address <ADDR>`              | Filter by owner address                                              |
+| `--all`                         | List all nodes on the network                                        |
+| `--corechannel-address <ADDR>`  | Address of the corechannel aggregate owner (defaults to mainnet)     |
+| `--json`                        | Output results as JSON                                               |
+| `--account <ACCOUNT>`           | Named account (defaults to the active account)                       |
+| `--private-key <KEY>`           | Hex-encoded private key                                              |
+| `--chain <CHAIN>`               | Signing chain                                                        |
+| `--help`                        | Show this message and exit                                           |
 
 ```bash
-# Get all core nodes in JSON format
-aleph node core --json
+# List all Compute Resource Nodes (CRN) in JSON format
+aleph node list --type crn --json
 
-# Get only active core nodes
-aleph node core --active
+# List all Core Channel Nodes (CCN)
+aleph node list --type ccn
 
-# Get core nodes filtered by address
-aleph node core --address ADDRESS
+# List all nodes on the network
+aleph node list --all
+
+# List CRNs filtered by owner address
+aleph node list --type crn --address ADDRESS
+
+# List CCNs filtered by owner address
+aleph node list --type ccn --address ADDRESS
 ```

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/port-forwarder.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/port-forwarder.md
@@ -1,11 +1,11 @@
 # Port Forwarding Management
 
-The `port-forwarder` command group allows you to manage port forwarding for your instances, enabling external access to specific ports on your VMs through IPv4 addresses.
+The `port-forward` command group (alias: `pfw`) allows you to manage port forwarding for your instances, enabling external access to specific ports on your VMs through IPv4 addresses.
 
 ## Overall Usage
 
 ```bash
-aleph instance port-forwarder [OPTIONS] KEY_COMMAND [ARGS]...
+aleph instance port-forward [OPTIONS] COMMAND [ARGS]...
 ```
 
 ### Options
@@ -20,9 +20,9 @@ aleph instance port-forwarder [OPTIONS] KEY_COMMAND [ARGS]...
 | --------- | ------------------------------------------------------------------------ |
 | `list`    | List all port forwards for a given address and/or item hash              |
 | `create`  | Create a new port forward for a specific item hash                       |
-| `update`  | Update an existing port forward for a specific item hash                 |
-| `delete`  | Delete a port forward or all port forwards for a specific item hash      |
-| `refresh` | Ask a CRN to fetch the latest port configurations from sender aggregates |
+| `update`  | Update an existing port forward's TCP/UDP flags                          |
+| `delete`  | Delete a port forward (a single port, or all ports if `--port` is omitted) |
+| `refresh` | Ask the CRN running this VM to re-read the aggregate immediately         |
 
 ## Listing Port Forwards
 
@@ -31,178 +31,159 @@ List all port forwards for a given address and/or specific item hash.
 ### Usage
 
 ```bash
-aleph instance port-forwarder list [OPTIONS]
+aleph instance port-forward list [OPTIONS]
 ```
 
 #### Options
 
-| Option                 | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--address`            | TEXT                                                                                                                                             | Target address to list port forwards for                                                 |
-| `--item-hash`          | TEXT                                                                                                                                             | Filter results to a specific item hash                                                   |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using                                                                      |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
+| Option               | Description                                                                                     |
+|----------------------|-------------------------------------------------------------------------------------------------|
+| `--address <ADDR>`   | Address to inspect (hex, account name, or alias). Defaults to the current default account's address |
+| `--vm-id <VM_ID>`    | Restrict the list to a single VM. Accepts a unique hash prefix                                  |
+| `--json`             | Output results as JSON                                                                          |
+| `--help`             | Show this message and exit                                                                      |
 
 ```bash
 # List all port forwards for your account
-aleph instance port-forwarder list
+aleph instance port-forward list
 
 # List port forwards for a specific instance
-aleph instance port-forwarder list --item-hash YOUR_INSTANCE_HASH
-
+aleph instance port-forward list --vm-id YOUR_INSTANCE_HASH
 ```
 
 ## Creating a Port Forward
 
-Create a new port forward for a specific item hash. Note that when you create an instance, port 22 (SSH) is automatically forwarded with TCP enabled.
+Create a new port forward for a specific item hash. When you create an instance, port 22 (SSH) is automatically forwarded with TCP enabled.
 
 ### Usage
 
 ```bash
-aleph instance port-forwarder create [OPTIONS] ITEM_HASH PORT
+aleph instance port-forward create [OPTIONS] <VM_ID> <PORT>
 ```
 
 #### Arguments
 
-| Argument    | Type    | Description                                        |
-| ----------- | ------- | -------------------------------------------------- |
-| `ITEM_HASH` | TEXT    | Item hash of the instance, program or IPFS website |
-| `PORT`      | INTEGER | Port number to forward (1-65535)                   |
+| Argument | Description                                        |
+|----------|----------------------------------------------------|
+| `VM_ID`  | Item hash of the instance, program or IPFS website |
+| `PORT`   | Port number to forward (1-65535)                   |
 
 #### Options
 
-| Option                 | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--tcp / --no-tcp`     |                                                                                                                                                  | Enable TCP forwarding for this port [default: tcp]                                       |
-| `--udp / --no-udp`     |                                                                                                                                                  | Enable UDP forwarding for this port [default: no-udp]                                    |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using                                                                      |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
+| Option                        | Description                                                              |
+|-------------------------------|--------------------------------------------------------------------------|
+| `--tcp <true\|false>`         | Allow TCP for this port [default: true] [possible values: true, false]   |
+| `--udp <true\|false>`         | Allow UDP for this port [default: false] [possible values: true, false]  |
+| `--json`                      | Output results as JSON                                                   |
+| `--channel <CHANNEL>`         | Channel for the AGGREGATE message                                        |
+| `--account <NAME>`            | Named account (defaults to the active account)                           |
+| `--private-key <K>`           | Hex-encoded private key                                                  |
+| `--dry-run`                   | Build and sign the message but don't submit it                           |
+| `--help`                      | Show this message and exit                                               |
 
 ```bash
-# Create a TCP port forward for port 80
-aleph instance port-forwarder create YOUR_INSTANCE_HASH 80
+# Create a TCP port forward for port 80 (TCP is enabled by default)
+aleph instance port-forward create YOUR_INSTANCE_HASH 80
 
-# Create a UDP port forward for port 53
-aleph instance port-forwarder create YOUR_INSTANCE_HASH 53 --no-tcp --udp
+# Create a UDP-only port forward for port 53
+aleph instance port-forward create YOUR_INSTANCE_HASH 53 --tcp false --udp true
 
 # Create a port forward for port 443 with both TCP and UDP
-aleph instance port-forwarder create YOUR_INSTANCE_HASH 443 --tcp --udp
+aleph instance port-forward create YOUR_INSTANCE_HASH 443 --tcp true --udp true
 ```
 
 ## Updating a Port Forward
 
-Update an existing port forward for a specific item hash.
+Update an existing port forward's TCP/UDP flags.
 
 ### Usage
 
 ```bash
-aleph instance port-forwarder update [OPTIONS] ITEM_HASH PORT
+aleph instance port-forward update [OPTIONS] <VM_ID> <PORT>
 ```
 
 #### Arguments
 
-| Argument    | Type    | Description                                        |
-| ----------- | ------- | -------------------------------------------------- |
-| `ITEM_HASH` | TEXT    | Item hash of the instance, program or IPFS website |
-| `PORT`      | INTEGER | Port number to update (1-65535)                    |
+| Argument | Description                                        |
+|----------|----------------------------------------------------|
+| `VM_ID`  | Item hash of the instance, program or IPFS website |
+| `PORT`   | Port number to update (1-65535)                    |
 
 #### Options
 
-| Option                 | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--tcp / --no-tcp`     |                                                                                                                                                  | Enable TCP forwarding for this port [default: tcp]                                       |
-| `--udp / --no-udp`     |                                                                                                                                                  | Enable UDP forwarding for this port [default: no-udp]                                    |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using                                                                      |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
+| Option                        | Description                                                              |
+|-------------------------------|--------------------------------------------------------------------------|
+| `--tcp <true\|false>`         | Allow TCP for this port [default: true] [possible values: true, false]   |
+| `--udp <true\|false>`         | Allow UDP for this port [default: false] [possible values: true, false]  |
+| `--json`                      | Output results as JSON                                                   |
+| `--channel <CHANNEL>`         | Channel for the AGGREGATE message                                        |
+| `--account <NAME>`            | Named account (defaults to the active account)                           |
+| `--private-key <K>`           | Hex-encoded private key                                                  |
+| `--dry-run`                   | Build and sign the message but don't submit it                           |
+| `--help`                      | Show this message and exit                                               |
 
 ```bash
 # Update port 80 to use both TCP and UDP
-aleph instance port-forwarder update YOUR_INSTANCE_HASH 80 --tcp --udp
+aleph instance port-forward update YOUR_INSTANCE_HASH 80 --tcp true --udp true
 
 # Update port 443 to use TCP only
-aleph instance port-forwarder update YOUR_INSTANCE_HASH 443 --tcp --no-udp
+aleph instance port-forward update YOUR_INSTANCE_HASH 443 --tcp true --udp false
 ```
 
 ## Deleting a Port Forward
 
-Delete a port forward or all port forwards for a specific item hash.
+Delete a port forward for a specific item hash. Omit `--port` to remove all port forwards for the VM.
 
 ### Usage
 
 ```bash
-aleph instance port-forwarder delete [OPTIONS] ITEM_HASH
+aleph instance port-forward delete [OPTIONS] <VM_ID>
 ```
 
 #### Arguments
 
-| Argument    | Type | Description                                        |
-| ----------- | ---- | -------------------------------------------------- |
-| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
+| Argument | Description                                        |
+|----------|----------------------------------------------------|
+| `VM_ID`  | Item hash of the instance, program or IPFS website |
 
 #### Options
 
-| Option                 | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--port`               | INTEGER                                                                                                                                          | Port number to delete. If not specified, all port forwards will be deleted               |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using                                                                      |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
+| Option              | Description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| `--port <PORT>`     | Port number to delete. If omitted, all port forwards will be deleted |
+| `--json`            | Output results as JSON                                               |
+| `--account <NAME>`  | Named account (defaults to the active account)                       |
+| `--private-key <K>` | Hex-encoded private key                                              |
+| `--help`            | Show this message and exit                                           |
 
 ```bash
 # Delete port forward for port 80
-aleph instance port-forwarder delete YOUR_INSTANCE_HASH --port 80
+aleph instance port-forward delete YOUR_INSTANCE_HASH --port 80
 
 # Delete all port forwards for an instance
-aleph instance port-forwarder delete YOUR_INSTANCE_HASH
+aleph instance port-forward delete YOUR_INSTANCE_HASH
 ```
 
 ## Refreshing Port Configurations
 
-Ask a CRN to fetch the latest port configurations from sender aggregates.
+Ask the CRN running this VM to re-read the aggregate immediately.
 
 ### Usage
 
 ```bash
-aleph instance port-forwarder refresh [OPTIONS] ITEM_HASH
+aleph instance port-forward refresh [OPTIONS] <VM_ID>
 ```
-
-#### Arguments
-
-| Argument    | Type | Description                                        |
-| ----------- | ---- | -------------------------------------------------- |
-| `ITEM_HASH` | TEXT | Item hash of the instance, program or IPFS website |
-
-#### Options
-
-| Option                 | Type                                                                                                                                             | Description                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `--private-key`        | TEXT                                                                                                                                             | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH                                                                                                                                             | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--chain`              | [ARB, AVAX, BASE, BLAST, BOB, BSC, CSDK, CYBER, DOT, ETH, FRAX, INK, LINEA, LISK, METIS, MODE, NEO, NULS, NULS2, OP, POL, SOL, TEZOS, WLD, ZORA] | Chain you are using                                                                      |
-| `--debug / --no-debug` |                                                                                                                                                  | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |                                                                                                                                                  | Show this message and exit                                                               |
 
 ```bash
 # Refresh port configurations for an instance
-aleph instance port-forwarder refresh YOUR_INSTANCE_HASH
+aleph instance port-forward refresh YOUR_INSTANCE_HASH
 ```
 
 ## Important Notes
 
-1. **Automatic SSH Port**: When you create an instance, we also create aggregate for port 22 (SSH) allowing you to SSH into your instance immediately.
+1. **Automatic SSH Port**: When you create an instance, port 22 (SSH) is automatically forwarded so you can SSH into your instance immediately.
 
-2. **IPv4 Access**: The port-forwarder functionality provides IPv4 access to your instances, making them accessible from systems that don't support IPv6.
+2. **IPv4 Access**: The port-forward functionality provides IPv4 access to your instances.
 
 3. **Port Limitations**: You can forward any port in the valid range (1-65535), but some CRNs may restrict certain ports for security reasons.
 

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/pricing.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/pricing.md
@@ -1,98 +1,77 @@
 # Pricing Information
 
-Display pricing for services available on Aleph Cloud, including compute instances, programs, storage, and GPU resources.
+Display pricing for VM instance configurations on Aleph Cloud using `aleph instance price`.
+
+> **Note:** Storage, website, and program pricing are not yet available as CLI commands. Check the [pricing pages](https://aleph.cloud/pricing) or use the SDK for those services.
 
 ## Usage
 
 ```bash
-aleph pricing [OPTIONS] SERVICE
+aleph instance price [OPTIONS]
 ```
-
-### Arguments
-
-| Argument  | Type                                                          | Description                    |
-| --------- | ------------------------------------------------------------- | ------------------------------ |
-| `SERVICE` | [storage, website, program, instance, confidential, gpu, all] | Service to display pricing for |
 
 ### Options
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `--tier` | INTEGER | Filter pricing by a specific tier number |
-| `--payment-type` | [hold, superfluid, credit] | Filter pricing by payment type |
-| `--json / --no-json` |  | Output as JSON instead of Rich Table [default: no-json] |
-| `--no-null` |  | Exclude null values in JSON output |
-| `--with-current-availability / --ignore-availability` |  | (GPU only) Show prices only for GPU types currently accessible on the network [default: ignore-availability] |
-| `--debug / --no-debug` |  | Enable debug logging [default: no-debug] |
-| `--help` |  | Show this message and exit |
+| Option              | Description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| `--size <SIZE>`     | Instance size slug (e.g. `1vcpu-2gb`, `4vcpu-8gb`)                  |
+| `--vcpus <N>`       | Number of virtual CPUs (custom sizing)                               |
+| `--memory <SIZE>`   | Memory size, e.g. `2GB`, `2048MB` (custom sizing)                   |
+| `--disk-size <SIZE>`| Disk size, e.g. `20GB`, `1TiB` (custom sizing)                      |
+| `--gpu [<MODEL>]`   | GPU model name (e.g. `h100`, `a100`, `rtx-4090`). Pass without value to list models |
+| `--list-gpus`       | List available GPU models and exit                                   |
+| `--confidential`    | Use confidential VM pricing (AMD SEV)                                |
+| `--json`            | Output results as JSON                                               |
+| `--help`            | Show this message and exit                                           |
 
 ## Examples
 
 ```bash
-# Display pricing for storage services
-aleph pricing storage
+# Display pricing for a size slug
+aleph instance price --size 4vcpu-8gb
 
-# Display pricing for website services
-aleph pricing website
+# Display pricing with custom resource specification
+aleph instance price --vcpus 2 --memory 4GB --disk-size 50GB
 
-# Display pricing for program services
-aleph pricing program
+# Display pricing for a GPU instance
+aleph instance price --gpu h100
 
-# Display pricing for instance services
-aleph pricing instance
+# Display pricing for a GPU instance with more resources than the minimum
+aleph instance price --gpu h100 --size 32vcpu-192gb
 
-# Display pricing for a specific tier
-aleph pricing instance --tier 2
+# List available GPU models
+aleph instance price --list-gpus
 
-# Display pricing filtered by payment type (holding tokens)
-aleph pricing instance --payment-type hold
+# Display confidential instance pricing
+aleph instance price --size 1vcpu-2gb --confidential
 
-# Display pricing for confidential instances
-aleph pricing confidential
-
-# Display pricing for GPU services with debugging enabled
-aleph pricing gpu --debug
-
-# Display GPU pricing showing only currently available GPUs on the network
-aleph pricing gpu --with-current-availability
-
-# Display pricing for all services available
-aleph pricing all
-
-# Output pricing as JSON
-aleph pricing instance --json
-
-# Output pricing as JSON without null values
-aleph pricing instance --json --no-null
+# Output as JSON
+aleph instance price --size 4vcpu-8gb --json
 ```
 
-## Service Types
+## Available GPU Models
 
-| Service | Description |
-|---------|-------------|
-| `storage` | Pricing for persistent file storage on IPFS via Aleph Cloud |
-| `website` | Pricing for hosting static websites |
-| `program` | Pricing for serverless functions (both ephemeral and persistent) |
-| `instance` | Pricing for standard virtual machine instances |
-| `confidential` | Pricing for confidential computing instances with encrypted memory |
-| `gpu` | Pricing for GPU-enabled instances |
-| `all` | Display pricing for all service types |
+Use `aleph instance price --list-gpus` to see currently available GPU models and their minimum resource requirements. Example output:
 
-## Payment Types
+| Model                | Min size       | VRAM    | Tier     |
+|----------------------|----------------|---------|----------|
+| `rtx-4000-ada`       | 3vcpu-18gb     | 20 GiB  | standard |
+| `rtx-3090`           | 4vcpu-24gb     | 24 GiB  | standard |
+| `rtx-4090`           | 6vcpu-36gb     | 24 GiB  | standard |
+| `l40s`               | 12vcpu-72gb    | 48 GiB  | standard |
+| `a100`               | 16vcpu-96gb    | 80 GiB  | premium  |
+| `h100`               | 24vcpu-144gb   | 80 GiB  | premium  |
+| `h200`               | 32vcpu-192gb   | 141 GiB | premium  |
 
-| Payment Type | Description |
-|--------------|-------------|
-| `hold` | Pay by holding ALEPH tokens (staking) |
-| `superfluid` | Pay-As-You-Go via token streaming |
-| `credit` | Pay using Aleph Cloud credits (prepaid balance) |
+GPU and confidential instances use separate pricing tiers and cannot be combined.
 
-## Understanding Tiers
+## Instance Size Slugs
 
-Each service type has multiple tiers that define the resource allocation:
+Size slugs provide preset configurations for standard instances:
 
-- **Tier 1**: Basic resources (1 compute unit)
-- **Tier 2-6+**: Progressively more resources (more vCPUs, RAM, disk)
+- `1vcpu-2gb` - 1 vCPU, 2 GB RAM
+- `2vcpu-4gb` - 2 vCPUs, 4 GB RAM
+- `4vcpu-8gb` - 4 vCPUs, 8 GB RAM
+- `8vcpu-16gb` - 8 vCPUs, 16 GB RAM
 
-Use `aleph pricing <service>` to see the specific resources allocated for each tier.
-
-**Going Beyond Tiers**: While tiers provide predefined resource configurations, you can customize and exceed tier limits by directly specifying `--vcpus`, `--memory`, or `--rootfs-size` when creating instances. See the [Resource Allocation section in the Instance documentation](./instance.md#resource-allocation) for more details on custom resource configuration.
+For custom sizing above these presets, use `--vcpus`, `--memory`, and `--disk-size` directly.

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
@@ -5,93 +5,101 @@ The `program` command group allows you to deploy and manage serverless functions
 ## Overall Usage
 
 ```bash
-aleph program [OPTIONS] KEY_COMMAND [ARGS]...
+aleph program [OPTIONS] COMMAND [ARGS]...
 ```
 
 ### Options
 
-| Command  | Description                   |
+| Option   | Description                   |
 | -------- | ----------------------------- |
 | `--help` | Show the help prompt and exit |
 
 ### Key Commands
 
-| Command           | Description                                                             |
-| ----------------- | ----------------------------------------------------------------------- |
-| `create / upload` | Deploy a new serverless function (create and upload are aliases)        |
-| `update`          | Update an existing function                                             |
-| `delete`          | Delete a program                                                        |
-| `list`            | List your deployed functions                                            |
-| `persistent`      | Recreate a non-persistent program as persistent (item hash will change) |
-| `unpersistent`    | Recreate a persistent program as non-persistent (item hash will change) |
-| `logs`            | Display the logs of a program                                           |
-| `runtime-checker` | Check versions used by a runtime (distribution, python, nodejs, etc...) |
+| Command      | Description                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| `create`     | Deploy a new serverless program                                         |
+| `update`     | Update the code of an existing program                                  |
+| `delete`     | Forget a program (and its code STORE unless `--keep-code`)              |
+| `list`       | List programs owned by an address                                       |
+| `persist`    | Recreate a program with `persistent=true` (new item hash)               |
+| `unpersist`  | Recreate a program with `persistent=false` (new item hash)              |
+| `logs`       | Fetch logs from one CRN running this program                            |
+| `show`       | Show full information about a single program                            |
 
 ## Creating a Program
+
+Deploy a new serverless program. The CLI auto-uploads `PATH` as a STORE message, then publishes the PROGRAM message referencing it.
 
 ### Usage
 
 ```bash
-aleph program create / upload [OPTIONS] PATH ENTRYPOINT
+aleph program create [OPTIONS] <PATH> <ENTRYPOINT>
 ```
 
 #### Arguments
 
-| Argument     | Type | Description                                                                                                             |
-| ------------ | ---- | ----------------------------------------------------------------------------------------------------------------------- |
-| `PATH`       | PATH | Path to your source code. Can be a directory, a .squashfs file or a .zip archive                                        |
-| `ENTRYPOINT` | TEXT | Your program entrypoint. Example: main:app for Python programs, else run.sh for a script containing your launch command |
+| Argument     | Description                                                                                                             |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `PATH`       | Source code path: directory, `.zip`, or `.squashfs`                                                                     |
+| `ENTRYPOINT` | Program entrypoint, e.g. `main:app` for Python or `run.sh` for a shell script                                          |
 
 #### Options
 
-| Options                                                | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`                                               | TEXT    | Name for your program                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `--runtime`                                            | TEXT    | Hash of the runtime to use for your program. You can also create your own runtime and pin it. [default: 63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696] (Use aleph program runtime-checker to inspect it)                                                                                                                                                                                                                                                                                                           |
-| `--compute-units                                       | INTEGER | Number of compute units to allocate. Compute units correspond to a tier that includes vcpus, memory, disk and gpu presets. For reference, run: aleph pricing --help                                                                                                                                                                                                                                                                                                                                                                   |
-| `--vcpus`                                              | INTEGER | Number of virtual CPUs to allocate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `--memory`                                             | INTEGER | Maximum memory (RAM) in MiB to allocate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `--timeout-seconds`                                    | FLOAT   | If vm is not called after [timeout_seconds] it will shutdown [default: 30.0]                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--internet / --no-internet`                           |         | Enable internet access for your program. By default, internet access is disabled [default: no-internet]                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `--updatable / --no-updatable`                         |         | Allow program updates. By default, only the source code can be modified without requiring redeployement (same item hash). When enabled (set to True), this option allows to update any other field. However, such modifications will require a program redeployment (new item hash) [default: no-updatable]                                                                                                                                                                                                                           |
-| `--beta / --no-beta`                                   |         | If true, you will be prompted to add message subscriptions to your program [default: no-beta]                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `--persistent / --no-persistent`                       |         | Create your program as persistent. By default, programs are ephemeral (serverless): they only start when called and then shutdown after the defined timeout delay. [default: no-persistent]                                                                                                                                                                                                                                                                                                                                           |
-| `--skip-volume / --no-skip-volume`                     |         | Skip prompt to attach more volumes [default: no-skip-volume]                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--persistent-volume`                                  | TEXT    | Persistent volumes are allocated on the host machine and are not deleted when the VM is stopped. Requires at least name, mount path, and size_mib. To add multiple, reuse the same argument. Example: --persistent-volume name=data,mount=/opt/data,size_mib=1000. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/persistent/                                                                                                                                                                                |
-| `--ephemeral-volume`                                   | TEXT    | Ephemeral volumes are allocated on the host machine when the VM is started and deleted when the VM is stopped. Requires at least mount path and size_mib. To add multiple, reuse the same argument. Example: --ephemeral-volume mount=/opt/tmp,size_mib=100                                                                                                                                                                                                                                                                           |
-| `--immutable-volume`                                   | TEXT    | Immutable volumes are pinned on the network and can be used by multiple VMs at the same time. They are read-only and useful for setting up libraries or other dependencies. Requires at least mount path and ref (volume message hash). use_latest is True by default, to use the latest version of the volume, if it has been amended. To add multiple, reuse the same argument. Example: --immutable-volume mount=/opt/packages,ref=25a3...8d94. For more info, see the docs: https://docs.aleph.cloud/computing/volumes/immutable/ |
-| `--skip-env-var / --no-skip-env-var`                   |         | Skip prompt to set environment variables [default: no-skip-env-var]                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `--env-vars`                                           | TEXT    | Environment variables to pass. They will be public and visible in the message, so don't include secrets. Must be a comma separated list. Example: KEY=value or KEY=value,KEY=value                                                                                                                                                                                                                                                                                                                                                    |
-| `--address`                                            | TEXT    | Address of the payer. In order to delegate the payment, your account must be authorized beforehand to publish on the behalf of this address. See the docs for more info: https://docs.aleph.cloud/protocol/permissions/                                                                                                                                                                                                                                                                                                               |
-| `--payment-chain`                                      | TEXT    | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `--channel`                                            | TEXT    | Aleph Cloud network channel where the message is or will be broadcasted [default: ALEPH-CLOUDSOLUTIONS]                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `--private-key`                                        | TEXT    | Your private key. Cannot be used with --private-key-file                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `--private-key-file`                                   | PATH    | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key]                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `--print-messages / --no-print-messages`               |         | Print the messages after creation [default: no-print-messages]                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `--print-code-message / --no-print-code-message`       |         | Print the code message after creation [default: no-print-code-message]                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `--print-program-message / --no-print-program-message` |         | Print the program message after creation [default: no-print-program-message]                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--verbose / --no-verbose`                             |         | Display additional information [default: verbose]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `--debug / --no-debug`                                 |         | Enable debug logging [default: no-debug]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `--help`                                               |         | Show this message and exit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-
-Deploy a serverless function from your local code:
+| Option                              | Description                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `--name <NAME>`                     | Friendly name (stored in `metadata.name`)                                                         |
+| `--runtime <RUNTIME>`               | Runtime: preset slug (e.g. `python3.12`) or a 64-char item hash. Defaults to `defaults.runtime`   |
+| `--size <SIZE>`                     | Resource preset slug (e.g. `1vcpu-2gb`). Mutually exclusive with `--vcpus` / `--memory`          |
+| `--vcpus <N>`                       | Number of virtual CPUs                                                                            |
+| `--memory <SIZE>`                   | Memory size (e.g. `2GB`, `512MiB`)                                                                |
+| `--timeout-seconds <N>`             | Idle timeout before shutdown (seconds) [default: 30]                                             |
+| `--internet`                        | Allow internet access from the program                                                            |
+| `--persistent`                      | Make the program persistent (always running) instead of ephemeral                                 |
+| `--updatable`                       | Allow future updates with `aleph program update`                                                  |
+| `--env-vars <VARS>`                 | Environment variables (comma-separated `KEY=value` pairs)                                         |
+| `--persistent-volume`               | `name=N,mount=PATH,size=SIZE[,persistence=host\|store]`; can be repeated                         |
+| `--ephemeral-volume`                | `mount=PATH,size=SIZE`; can be repeated                                                           |
+| `--immutable-volume`                | `ref=HASH,mount=PATH[,use_latest=BOOL]`; can be repeated                                         |
+| `--storage-engine <ENGINE>`         | Storage engine for the code STORE: `storage` (default) or `ipfs`                                 |
+| `--payment-type <TYPE>`             | `hold` (default) or `credit`                                                                      |
+| `--channel <CHANNEL>`               | Channel name                                                                                      |
+| `--on-behalf-of <ADDR>`             | Sign on behalf of another address (requires authorization)                                        |
+| `--account <ACCOUNT>`               | Named account (defaults to the active account)                                                    |
+| `--private-key <KEY>`               | Hex-encoded private key (or set `ALEPH_PRIVATE_KEY`)                                             |
+| `--chain <CHAIN>`                   | Signing chain (required with `--private-key`)                                                     |
+| `--dry-run`                         | Build and sign the message but don't submit it                                                    |
+| `--help`                            | Show this message and exit                                                                        |
 
 ```bash
 # Deploy a Python function
 aleph program create ./updated_prog.zip main:app
 
-# Deploy a persistent program named test and with a specific configuration
+# Deploy a persistent program with a specific runtime and resources
 aleph program create ./updated_prog.zip main:app \
   --name test \
   --persistent \
-  --runtime 63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696 \
-  --payment-chain AVAX \
-  --compute-units 1 \
-  --vcpus 1 \
-  --memory 512 \
-  --timeout-seconds 60 \
-  --skip-volume \
-  --skip-env-var
+  --runtime python3.12 \
+  --size 1vcpu-2gb \
+  --timeout-seconds 60
+```
+
+## Showing Program Details
+
+Show full information about a single program: creation time, ownership, per-ref freshness for code, runtime, data, and volumes.
+
+### Usage
+
+```bash
+aleph program show [OPTIONS] <ITEM_HASH>
+```
+
+```bash
+# Show details of a program
+aleph program show ITEM_HASH
+
+# Show as JSON
+aleph program show ITEM_HASH --json
 ```
 
 ## Deleting a Program
@@ -99,37 +107,29 @@ aleph program create ./updated_prog.zip main:app \
 ### Usage
 
 ```bash
-aleph program delete [OPTIONS] ITEM_HASH
+aleph program delete [OPTIONS] <ITEM_HASH>
 ```
-
-#### Arguments
-
-| Argument    | Type      | Description            |
-| ----------- | --------- | ---------------------- |
-| `ITEM_HASH` | ITEM HASH | Item hash to unpersist |
 
 #### Options
 
-| Options                                | Type | Description                                                                              |
-| -------------------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--reason`                             | TEXT | Reason for deleting the program [default: User deletion]                                 |
-| `--keep-code / --no-keep-code`         |      | Keep the source code intact instead of deleting it [default: no-keep-code]               |
-| `--chain`                              | TEXT | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]              |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |      | Print the message after deletion [default: no-print-message]                             |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                               |      | Show this message and exit                                                               |
+| Option               | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| `--reason <REASON>`  | Reason for deletion (recorded on the FORGET message) [default: "User deletion"] |
+| `-y, --yes`          | Skip the confirmation prompt                                             |
+| `--keep-code`        | Keep the source code STORE instead of deleting it                        |
+| `--account <NAME>`   | Named account (defaults to the active account)                           |
+| `--private-key <K>`  | Hex-encoded private key                                                  |
+| `--dry-run`          | Build and sign the message but don't submit it                           |
+| `--help`             | Show this message and exit                                               |
 
 ```bash
-# Deleting a program
+# Delete a program
 aleph program delete ITEM_HASH
 ```
 
 ## Listing Programs
 
-List all programs associated to an account
+List all programs associated with an account.
 
 ### Usage
 
@@ -139,86 +139,46 @@ aleph program list [OPTIONS]
 
 #### Options
 
-| Options                | Type | Description                                                                              |
-| ---------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--address`            | TEXT | Owner address of the programs                                                            |
-| `--chain`              | TEXT | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]              |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--json / --no-json`   |      | Print as json instead of rich table [default: no-json]                                   |
-| `--debug / --no-debug` |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |      | Show this message and exit                                                               |
+| Option              | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `--address <ADDR>`  | Owner address of the programs                  |
+| `--json`            | Output results as JSON                         |
+| `--account <NAME>`  | Named account (defaults to the active account) |
+| `--private-key <K>` | Hex-encoded private key                        |
+| `--help`            | Show this message and exit                     |
 
 ```bash
-# Listing all your programs
+# List all your programs
 aleph program list
 
-# Listing every programs of a specified user as json
+# List programs for a specific address as JSON
 aleph program list --address ADDRESS --json
 ```
 
-## Make a Program Persistant
+## Make a Program Persistent
 
-Recreate a non-persistent program as persistent (item hash will change). **The program must be updatable and yours**
+Recreate a non-persistent program as persistent (item hash will change). The program must be updatable.
 
 ### Usage
 
 ```bash
-aleph program persist [OPTIONS] ITEM_HASH
+aleph program persist [OPTIONS] <ITEM_HASH>
 ```
-
-#### Arguments
-
-| Argument    | Type      | Description                          |
-| ----------- | --------- | ------------------------------------ |
-| `ITEM_HASH` | ITEM HASH | Item hash of the programm to persist |
-
-#### Options
-
-| Options                                | Type | Description                                                                              |
-| -------------------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--keep-prev / --no-keep-prev`         |      | Keep the previous program intact instead of deleting it [default: no-keep-prev]          |
-| `--chain`                              | TEXT | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]              |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |      | Print the message after deletion [default: no-print-message]                             |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                               |      | Show this message and exit                                                               |
 
 ```bash
 # Recreate a non-persistent program as persistent
 aleph program persist ITEM_HASH
 ```
 
-## Make a Program Non-persistant
+## Make a Program Non-Persistent
 
-Recreate a persistent program as non-persistent (item hash will change). **The program must be updatable and yours**
+Recreate a persistent program as non-persistent (item hash will change). The program must be updatable.
 
 ### Usage
 
 ```bash
-aleph program unpersist [OPTIONS] ITEM_HASH
+aleph program unpersist [OPTIONS] <ITEM_HASH>
 ```
-
-#### Arguments
-
-| Argument    | Type      | Description                         |
-| ----------- | --------- | ----------------------------------- |
-| `ITEM_HASH` | ITEM HASH | Item hash of the program to persist |
-
-#### Options
-
-| Options                                | Type | Description                                                                              |
-| -------------------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--keep-prev / --no-keep-prev`         |      | Keep the previous program intact instead of deleting it [default: no-keep-prev]          |
-| `--chain`                              | TEXT | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]              |
-| `--private-key`                        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`                   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--print-message / --no-print-message` |      | Print the message after deletion [default: no-print-message]                             |
-| `--verbose / --no-verbose`             |      | Display additional information [default: verbose]                                        |
-| `--debug / --no-debug`                 |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                               |      | Show this message and exit                                                               |
 
 ```bash
 # Recreate a persistent program as non-persistent
@@ -227,76 +187,22 @@ aleph program unpersist ITEM_HASH
 
 ## Display Logs of a Program
 
-Display the logs of a program, it will only show logs from the selected CRN
+Fetch logs from one CRN running this program.
 
 ### Usage
 
 ```bash
-aleph program logs [OPTIONS] ITEM_HASH
+aleph program logs [OPTIONS] <ITEM_HASH>
 ```
-
-#### Arguments
-
-| Argument    | Type      | Description              |
-| ----------- | --------- | ------------------------ |
-| `ITEM_HASH` | ITEM HASH | Item hash of the program |
-
-#### Options
-
-| Options                | Type | Description                                                                              |
-| ---------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--chain`              | TEXT | Chain you want to use to pay for your program can be [AVAX, BASE, ETH, SOL]              |
-| `--private-key`        | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`   | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--domain`             | TEXT | URL of the CRN (Compute node) on which the program is running                            |
-| `--debug / --no-debug` |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`               |      | Show this message and exit                                                               |
 
 ```bash
 # Display logs of a program
 aleph program logs ITEM_HASH
 ```
 
-## Checking versions
-
-Check versions used by a runtime (distribution, python, nodejs, etc)
-
-### Usage
-
-```bash
-aleph program runtime-checker [OPTIONS] ITEM_HASH
-```
-
-#### Arguments
-
-| Argument    | Type      | Description                       |
-| ----------- | --------- | --------------------------------- |
-| `ITEM_HASH` | ITEM HASH | Item hash of the runtime to check |
-
-#### Options
-
-| Options                    | Type | Description                                                                              |
-| -------------------------- | ---- | ---------------------------------------------------------------------------------------- |
-| `--chain`                  | TEXT | Chain for the address, it can be [AVAX, BASE, ETH, SOL]                                  |
-| `--private-key`            | TEXT | Your private key. Cannot be used with --private-key-file                                 |
-| `--private-key-file`       | PATH | Path to your private key file [default: /home/$USER/.aleph-im/private-keys/ethereum.key] |
-| `--verbose / --no-verbose` |      | Display additional information [default: no-verbose]                                     |
-| `--debug / --no-debug`     |      | Enable debug logging [default: no-debug]                                                 |
-| `--help`                   |      | Show this message and exit                                                               |
-
-```bash
-# Checking versions for a program
-aleph program runtime-checker ITEM_HASH
-```
-
 ## Supported Runtimes
 
-Aleph Cloud supports multiple programming languages:
-
-- `python-3.10` - Python 3.10
-- `node-18` - Node.js 18
-- `node-20` - Node.js 20
-- `rust-1.70` - Rust 1.70
+Aleph Cloud supports multiple programming languages. Use a preset slug (e.g. `python3.12`) or provide a 64-char item hash for a custom runtime. Omit `--runtime` to use the network's default runtime.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Part of the Python→Rust CLI docs migration. Rewrites all 11 command-reference pages per the Rust CLI command tree (v0.10.3), verified against the binary at every step.

- **instance**: `allocate`→`start`; `gpu` subcommand→`create --gpu <MODEL>`; confidential subcommands removed (pointer to guide added); `port-forwarder`→`port-forward` (alias `pfw`); new subsections for `show`, `ssh`, `erase`, `price`, `backup`
- **program**: `create/upload` alias dropped (just `create`); `runtime-checker` section removed; `show` subsection added
- **file**: `forget`→`delete`; flags updated to Rust CLI (`--count`/`--sort-order`/`--ref`/`--output`/`--stdout`); upload section updated with new flags
- **message**: `find`→`list`; `post`, `amend`, `watch`, `sign` sections deleted (note pointing to `aleph post`); `retry` and `sync` subsections added
- **aggregate**: `post`→`create`; `authorize`, `revoke`, `permissions` sections replaced with "Delegated permissions" note pointing to `aleph authorization` group
- **domain**: `info`→`list`; `remove` subsection added; `--on-behalf-of` flag noted for delegated updates
- **node**: `compute`→`node list --type crn`; `core`→`node list --type ccn`; `--active` flag dropped (does not exist in Rust CLI); registration/staking commands noted
- **pricing**: rescoped to `aleph instance price`; GPU models table from `--list-gpus`; note that storage/website/program pricing have no CLI command yet
- **credits**: `credits show`→`account balance`; `credits history`→`credit history`; `credit buy` and `credit transfer` subsections added
- **about**: repurposed as "Version & shell completions" (`aleph --version`; `aleph completions <shell>`)
- **port-forwarder**: `port-forwarder`→`port-forward` throughout; filename kept for sidebar links

## Test plan

- [x] `npm run docs:build` — build complete
- [x] Residual grep for old command patterns — empty (only hit is a `.md` filename link, not a command)
- [x] All examples traceable to `aleph <cmd> --help` output
- [x] Confidential sections removed with pointer to guide
- [x] Exactly 11 files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)