### PR TITLE
docs(compute): migrate function & instance tutorials to the Rust CLI

### DIFF
--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
@@ -27,9 +27,7 @@ You could also reuse the same dependencies for multiple programs.
 sudo apt install python-pip python-venv squashfs-tools
 ```
 
-```shell
-pip install aleph-client
-```
+Install the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) - e.g. `brew install aleph-im/homebrew-tap/aleph-cli` (macOS) or the APT repo on Linux (`curl -fsSL https://apt.aleph.im/install.sh | sudo bash && sudo apt install aleph-cli`).
 
 ## Create the volume
 
@@ -75,7 +73,7 @@ aleph file pin QmWWX6BaaRkRSr2iNdwH5e29ACPg2nCHHXTRTfuBmVm3Ga
 ## Create your program
 
 ```shell
-aleph program upload ./my-program main:app
+aleph program create ./my-program main:app
 ```
 
 Press Enter at the following prompt to use the default runtime:

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
@@ -131,10 +131,10 @@ ipfs add extra-lib.squashfs
 
 and retrieve the printed IPFS hash.
 
-Pin the volume on Aleph Cloud using `aleph pin`:
+Pin the volume on Aleph Cloud using `aleph file pin`:
 
 ```shell
-aleph pin $IPFS_HASH --channel TEST
+aleph file pin $IPFS_HASH --channel TEST
 ```
 
 Mention the volume in the prompt of `aleph program (...)`
@@ -145,7 +145,7 @@ Follow the same procedure you used to create an immutable volume, but pin it wit
 reference to the original using:
 
 ```shell
-aleph pin $IPFS_HASH --ref $ORIGINAL_HASH
+aleph file pin $IPFS_HASH --ref $ORIGINAL_HASH
 ```
 
 ### Host persistent volumes

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
@@ -12,8 +12,8 @@ We expect you to know a little Python and have some experience with Python web f
 The first chapters of the [FastAPI Tutorial](https://fastapi.tiangolo.com/tutorial/) should cover
 enough to get started.
 
-To complete this tutorial, you will use the `aleph` command from
-[aleph-client](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
+To complete this tutorial, you will use the `aleph` command from the
+[Aleph CLI](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on
 Aleph Cloud.
 
@@ -37,14 +37,15 @@ brew tap cuber/homebrew-libsecp256k1
 brew install libsecp256k1 squashfs
 ```
 
-You will also need [Uvicorn](https://www.uvicorn.org/) for local testing
-and the [Python Aleph Cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+You will also need [Uvicorn](https://www.uvicorn.org/) for local testing:
 
 - Linux/macOs:
 
 ```
-pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
+pip3 install "uvicorn[standard]" fastapi eth_account
 ```
+
+Install the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) - e.g. `brew install aleph-im/homebrew-tap/aleph-cli` (macOS) or the APT repo on Linux (`curl -fsSL https://apt.aleph.im/install.sh | sudo bash && sudo apt install aleph-cli`).
 
 ## Understanding Aleph Cloud programs
 
@@ -166,21 +167,21 @@ The `--reload` option will automatically reload your app when the code changes.
 
 ## Upload your program on Aleph Cloud
 
-After installing [aleph-client](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
+After installing the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
 
 ```shell
 aleph --help
 ```
 
 Let's upload our program.
-The `aleph program CODE_DIR ENTRYPOINT` command will package the `CODE_DIR` code directory and configure the program
+The `aleph program create PATH ENTRYPOINT` command will package the `PATH` code directory and configure the program
 to run the `ENTRYPOINT` command.
 For Python programs, `ENTRYPOINT` can be the module path to an ASGI application.
 
 This command will upload our Python code and configure `main:app` as the ASGI application.
 
 ```shell
-aleph program upload ./my-program main:app
+aleph program create ./my-program main:app
 ```
 
 Press Enter at the following prompt to use the default runtime:

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/rust.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/rust.md
@@ -85,21 +85,21 @@ Compile your program in release mode:
 cargo build --release
 ```
 
-After installing [aleph-client](https://github.com/aleph-im/aleph-client), you should have access to the `aleph` command:
+After installing the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
 
 ```shell
 aleph --help
 ```
 
-The `aleph program CODE_DIR ENTRYPOINT` command will package the `CODE_DIR` code directory and configure the program
+The `aleph program create PATH ENTRYPOINT` command will package the `PATH` code directory and configure the program
 to run the `ENTRYPOINT` command.
 For our program, the code directory is the build directory and the entrypoint is the name of our executable.
 
 ```shell
-aleph program ./target/release/example_http_rust example_http_rust
+aleph program create ./target/release/example_http_rust example_http_rust
 ```
 
 If your program takes arguments, pass them in the entrypoint by using quotes: `"example_http_rust --help"`.
 
 > ℹ️ If you get the error `Invalid zip archive`, you are probably missing the Squashfs user tool `mksquashfs`.
-> In that case, first create the squashfs archive and then upload it using `aleph program ./target/release/example_http_rust.squashfs example_http_rust`.
+> In that case, first create the squashfs archive and then upload it using `aleph program create ./target/release/example_http_rust.squashfs example_http_rust`.

--- a/docs/devhub/compute-resources/functions/advanced/update-programs.md
+++ b/docs/devhub/compute-resources/functions/advanced/update-programs.md
@@ -16,28 +16,27 @@ The first way to update a program is to emit a new PROGRAM message that replaces
 This is as simple as setting the `replaces` field of the PROGRAM message to the hash of the program
 you want to modify.
 
-For example, let's say you wrote a program and configured it to use 1 core.
-It turns out that this was a little short-sighted, and you actually need 4 cores
-to serve more requests.
-You can update your program with the `aleph` CLI.
-There are two options, whether you need to update your code or not.
-
-If you want to update your code:
+For example, you find a bug in your request handler, or you want to ship a new
+endpoint. Publish the new version with the `aleph` CLI:
 
 ```bash
 aleph program update $PROGRAM_HASH $CODE_DIR
 ```
 
-Otherwise:
+:::note Prerequisite: updatable program
+`aleph program update` only works if the program was created with the `--updatable` flag. Without it, the program is immutable and the update command will fail. Programs created in the getting-started tutorial are immutable by default.
+:::
 
-```bash
-aleph message amend $PROGRAM_HASH
-```
+This re-uploads the code and publishes a replacement PROGRAM message; the item
+hash is unchanged. Your program is updated as soon as the replacement message
+reaches the Compute Resource Node(s) executing it.
 
-This will open your favorite command-line editor and let you update the message.
-For our example, we will just update the `resource.vcpus` property from 1 to 4.
-Once saved, the new message is emitted as a replacement for the original program.
-Your program will be updated as soon as the message reaches the Compute Resource Node(s) executing it.
+`aleph program update` only replaces the program's code. Resource settings such
+as `vcpus`, `memory`, runtime, or volume layout are fixed at create time, so to
+run with a different configuration you publish a fresh program with
+`aleph program create` and the new parameters (the new program has a new item
+hash).
+
 
 ### Immutable programs
 
@@ -59,15 +58,24 @@ There are numerous cases where this is the best option:
 - You just want to upgrade your code
 - etc.
 
-The operation is similar to updating a program, except that we will update the STORE message
+The operation is similar to updating a program, except that we will replace the STORE message
 that created the file instead of the PROGRAM message.
 Let's use the `aleph` CLI to update one of our volumes.
 
-```
-aleph message amend $VOLUME_REF
+Re-upload the updated volume file:
+
+```bash
+aleph file upload $VOLUME_PATH
 ```
 
-Where `VOLUME_REF` is the `item_hash` of the STORE message that stores the file on Aleph Cloud.
+Or, if the file already exists on IPFS, pin it directly:
+
+```bash
+aleph file pin $IPFS_HASH
+```
+
+Where `VOLUME_PATH` / `IPFS_HASH` refers to the updated volume content. The new STORE message hash
+becomes the new volume reference. For immutable volumes mounted with `use_latest=true`, the program picks up the new upload automatically; for `use_latest=false`, recreate the program referencing the new hash.
 You must either own this file or have the permission to update this file
 (see [Permissions](/devhub/building-applications/messaging/permissions)).
 

--- a/docs/devhub/compute-resources/functions/getting-started.md
+++ b/docs/devhub/compute-resources/functions/getting-started.md
@@ -9,7 +9,7 @@ We will build a simple HTTP server and add features as we go.
 
 Before you begin this tutorial, ensure that you have the following:
 
-- A computer with Python and the [aleph-client](https://github.com/aleph-im/aleph-client/) utility installed
+- A computer with Python and the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) installed
 - An Ethereum account with at least 2000 ALEPH token
 - Working knowledge of Python
 
@@ -20,8 +20,8 @@ We expect you to know a little Python and have some experience with Python web f
 The first chapters of the [FastAPI Tutorial](https://fastapi.tiangolo.com/tutorial/) should cover
 enough to get started.
 
-To complete this tutorial, you will use the `aleph` command from
-[aleph-client](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
+To complete this tutorial, you will use the `aleph` command from the
+[Aleph CLI](/devhub/sdks-and-tools/aleph-cli/), the `fastapi` framework to create a
 simple API and the `uvicorn` server to test your program on your desktop before uploading it on
 aleph.cloud.
 
@@ -45,14 +45,15 @@ brew tap cuber/homebrew-libsecp256k1
 brew install libsecp256k1 squashfs
 ```
 
-You will also need [Uvicorn](https://www.uvicorn.org/) for local testing
-and the [Python aleph.cloud client](https://github.com/aleph-im/aleph-client) for it's command-line tools:
+You will also need [Uvicorn](https://www.uvicorn.org/) for local testing:
 
 - Linux/macOs:
 
 ```
-pip3 install "uvicorn[standard]" aleph-client fastapi eth_account
+pip3 install "uvicorn[standard]" fastapi eth_account
 ```
+
+Install the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) - e.g. `brew install aleph-im/homebrew-tap/aleph-cli` (macOS) or the APT repo on Linux (`curl -fsSL https://apt.aleph.im/install.sh | sudo bash && sudo apt install aleph-cli`).
 
 ## Understanding aleph cloud programs
 
@@ -174,14 +175,14 @@ The `--reload` option will automatically reload your app when the code changes.
 
 ## Upload your program on aleph.cloud
 
-After installing [aleph-client](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
+After installing the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/), you should have access to the `aleph` command:
 
 ```shell
 aleph --help
 ```
 
 Let's upload our program.
-The `aleph program CODE_DIR ENTRYPOINT` command will package the `CODE_DIR` code directory and configure the program
+The `aleph program create PATH ENTRYPOINT` command will package the `PATH` code directory and configure the program
 to run the `ENTRYPOINT` command.
 For Python programs, `ENTRYPOINT` can be the module path to an ASGI application.
 
@@ -195,7 +196,7 @@ or [dependency volume](/devhub/compute-resources/functions/advanced/custom-build
 This command will upload our Python code and configure `main:app` as the ASGI application.
 
 ```shell
-aleph program upload ./my-program main:app
+aleph program create ./my-program main:app
 ```
 
 Press Enter at the following prompt to use the default runtime:

--- a/docs/devhub/compute-resources/functions/index.md
+++ b/docs/devhub/compute-resources/functions/index.md
@@ -73,7 +73,7 @@ message = {
 
 Before you begin this tutorial, ensure that you have the following:
 
-- A computer with Python and the [aleph-client](https://github.com/aleph-im/aleph-client/) utility installed
+- A computer with Python and the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) installed
 - An Ethereum account with at least 2000 ALEPH token
 - Working knowledge of Python
 
@@ -110,7 +110,7 @@ uvicorn main:app --reload
 To run the program in a persistent manner on the aleph.cloud network, use:
 
 ```shell
-aleph program upload --persistent ./src/ main:app
+aleph program create --persistent ./src/ main:app
 ```
 
 You can stop the execution of the program using:

--- a/docs/devhub/compute-resources/gpu-instances/index.md
+++ b/docs/devhub/compute-resources/gpu-instances/index.md
@@ -2,17 +2,26 @@
 
 This section outlines the process of starting a GPU instance on the Aleph Network and configuring the GPU on it.
 
-The [aleph-client](https://github.com/aleph-im/aleph-client/) command-line tool is required.<br>
+The [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) is required.<br>
 See [CLI Reference](/devhub/sdks-and-tools/aleph-cli/) or use `--help` for a quick overview of a specific command.
 
 ## Setup
 
 ### Create an instance with GPU
 
-The CLI provides a streamlined command to create a GPU instance. You will be prompted to choose a specific GPU available on a compatible CRN (Compute Resource Node), where your instance will be deployed. Alternatively, you can create your GPU instance on [Aleph Cloud](https://app.aleph.cloud).
+The CLI provides a streamlined command to create a GPU instance. Use `aleph instance price --list-gpus` to list available GPU models, then pass the model name via `--gpu`. Alternatively, you can create your GPU instance on [Aleph Cloud](https://app.aleph.cloud).
 
 ```shell
-aleph instance gpu
+aleph instance create my-gpu-instance \
+  --image ubuntu26 \
+  --gpu rtx4090 \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
+```
+
+For an interactive walkthrough that lets you pick a GPU and CRN from a list, pass `-i`:
+
+```shell
+aleph instance create -i my-gpu-instance
 ```
 
 <br/><br/>

--- a/docs/devhub/compute-resources/standard-instances/custom-images.md
+++ b/docs/devhub/compute-resources/standard-instances/custom-images.md
@@ -39,7 +39,7 @@ sudo apt update
 sudo apt install --yes cloud-image-utils qemu-system-x86
 ```
 
-The [aleph-client](/devhub/sdks-and-tools/aleph-cli/)
+The [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/)
 
 ### Specify user data
 
@@ -119,8 +119,8 @@ curl -L -X POST -F file=@destination-image.img "http://ipfs-2.aleph.im/api/v0/ad
 
 Pin the ipfs file on aleph.im via:
 
-```
-aleph file pin <ipfs hash>
+```bash
+aleph file pin $IPFS_HASH
 ```
 
 ### Check that it is present
@@ -133,16 +133,16 @@ aleph file list
 
 ### Test and use your custom image.
 
-When creating a new image, use the item hash in the custom runtime field
+When creating a new instance, pass the item hash via `--image`:
 
-```
-aleph instance create
-Preset to default chain: ETH
-Which payment type do you want to use? [hold/superfluid/nft] (superfluid): hold
-Use a custom rootfs or one of the following prebuilt ones: [ubuntu22/ubuntu24/debian12/custom] (ubuntu22): b6ff5c3a8205d1ca4c7c3369300eeafff498b558f71b851aa2114afd0a532717
+```shell
+aleph instance create my-instance \
+  --image b6ff5c3a8205d1ca4c7c3369300eeafff498b558f71b851aa2114afd0a532717 \
+  --size 1vcpu-2gb \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
 ```
 
-(or via the `--runtime` option)
+(or use `-i` / `--interactive` to be prompted for each field)
 
 ## Sources and references
 

--- a/docs/devhub/compute-resources/standard-instances/index.md
+++ b/docs/devhub/compute-resources/standard-instances/index.md
@@ -8,7 +8,7 @@ You can create, manage your instances via the [Aleph Cloud Console](https://app.
 
 ## via the CLI
 
-The [aleph-client](https://github.com/aleph-im/aleph-client/) command-line tool is required.<br>
+The [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) is required.<br>
 See [CLI Reference](/devhub/sdks-and-tools/aleph-cli/) or use `--help` for a quick overview of a specific command.
 
 ### Create a Standard Instance via the CLI
@@ -17,10 +17,17 @@ Prerequisite: A ssh key so you can log onto your VM, you can create one using th
 To create a standard instance, use:
 
 ```shell
-aleph instance create
+aleph instance create my-instance \
+  --image ubuntu26 \
+  --size 1vcpu-2gb \
+  --ssh-pubkey-file ~/.ssh/id_ed25519.pub
 ```
 
-An instance will guide you and ask you question on how you want to configure your VM: base system, disk size, etc...
+For an interactive walkthrough that prompts for any missing fields and lets you pick a CRN from a list, pass `-i`:
+
+```shell
+aleph instance create -i my-instance
+```
 
 Once the process is complete, your VM should be ready to use in a few minutes.
 


### PR DESCRIPTION
Part of the Python→Rust CLI docs migration.

## Changes

- `aleph program upload` → `aleph program create` (all occurrences)
- `aleph program upload --persistent` → `aleph program create --persistent` (confirmed `--persistent` flag exists)
- `aleph instance gpu` → `aleph instance create --gpu <MODEL> --image ... --ssh-pubkey-file ...` (using real GPU model from `aleph instance price --list-gpus`)
- `aleph pin` → `aleph file pin` (features.md)
- `aleph message amend` removed — replaced with `aleph program update` for code changes and `aleph file upload`/`aleph file pin` for volume updates; config-only changes documented via delete+recreate pattern
- `aleph-client` install lines removed; Aleph CLI install step added (brew/APT)
- `standard-instances/index.md` and `custom-images.md`: bare `aleph instance create` replaced with proper examples including required `--image` and `--ssh-pubkey-file` flags
- All flags verified against `/home/olivier/git/aleph/aleph-rs/target/debug/aleph --help` before use

## Verification

- `npm run docs:build` → build complete
- `grep -rnE "aleph-client|aleph program upload|aleph instance gpu|aleph pin |aleph message amend"` → no output