### PR TITLE
docs(hosting): migrate domain & port-forwarding guides to the Rust CLI

### DIFF
--- a/docs/devhub/deploying-and-hosting/custom-domains/instance.md
+++ b/docs/devhub/deploying-and-hosting/custom-domains/instance.md
@@ -71,14 +71,18 @@ ping -6 <yourdomain>
 
 ## via the CLI
 
-- The [aleph-client](https://github.com/aleph-im/aleph-client/) command-line tool is required.<br>
+- The [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) is required - e.g. `brew install aleph-im/homebrew-tap/aleph-cli` (macOS) or the APT repo on Linux.<br>
 - See [CLI Reference](/devhub/sdks-and-tools/aleph-cli/) or use `--help` for a quick overview of a specific command.
 
 All the domain commands are in the [`aleph domain` command subgroup](https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/commands/domain.html).
 
-The `aleph domain add` offer an interactive assistant that will guide you on the process of how to set up the instance name.
+`aleph domain add` creates or updates a domain entry pointing at a target instance:
 
-You can also do each step manually
+```bash
+aleph domain add --target <INSTANCE_HASH> --kind instance <YOUR_DOMAIN>
+```
+
+After running this command, configure your DNS records as described in the [Manual DNS Setup](#manual-dns-setup) section below.
 
 ## Manual DNS Setup
 
@@ -94,8 +98,10 @@ Adding a custom domain to your Aleph Cloud instance involves:
 Use the command `aleph domain attach` or modify the `domain` key of your AGGREGATE.
 
 ```bash
-aleph domain attach
+aleph domain attach --to <INSTANCE_HASH> <YOUR_DOMAIN>
 ```
+
+Pass `--on-behalf-of <ADDRESS>` if you are managing the domain on behalf of another address.
 
 Example aggregate
 

--- a/docs/devhub/deploying-and-hosting/ipv4/ipv4-port-forwarding.md
+++ b/docs/devhub/deploying-and-hosting/ipv4/ipv4-port-forwarding.md
@@ -43,27 +43,33 @@ if the custom domain was properly setup the dns should resolve to the hosting CR
 
 ## From the aleph CLI
 
-Port forwarding for your instance can be managed via the `port-forwarder` subcommand group.
+Port forwarding for your instance can be managed via the `port-forward` subcommand group (alias: `pfw`).
 
-The list of command can be seen using `aleph instance port-forwarder`
+The list of commands can be seen using `aleph instance port-forward --help`
 
 ## Create a new port forwarding
 
-Set up a forward for your address using :
+Set up a forward for your address using:
 
 ```bash
-aleph instance port-forwarder create <instance hash> <port>
+aleph instance port-forward create <VM_ID> <PORT>
 ```
 
-For example :
+By default TCP is enabled and UDP is disabled. Use `--tcp false` or `--udp true` to change this:
+
+```bash
+aleph instance port-forward create <VM_ID> <PORT> --tcp true --udp false
+```
+
+For example:
 
 ```
-aleph instance port-forwarder create a8a2d6ad3858e1eedc985d89c33ab6898babe6ae5d68ce3cdafc78d20dbe4cd8 22
+aleph instance port-forward create a8a2d6ad3858e1eedc985d89c33ab6898babe6ae5d68ce3cdafc78d20dbe4cd8 22
 ```
 
 The port forwarding may take one minute or so to set up.
 
-You can check on which external port your internal port is exposed, using the `aleph instance list ` command
+You can check on which external port your internal port is exposed, using the `aleph instance list` command
 
 After setup is complete, you can access your instance using the CRN domain name or ip and the external port.
 
@@ -75,35 +81,35 @@ if it is properly setup the dns should resolve to the hosting CRN ipv4 ip.
 If it fails to set up, you can try forcing a refresh using the `refresh` command
 
 ```bash
-aleph instance port-forwarder  refresh
+aleph instance port-forward refresh <VM_ID>
 ```
 
 List port forwarding
 
 ```bash
- aleph instance port-forwarder list
+aleph instance port-forward list
 ```
 
-```example output
-aleph instance port-forwarder list
-Getting port forwards for address: 0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90
-                                                   Port Forwards
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━┯━━━━━┯━━━━━┓
-┃ Item Hash                                                        │ Name                       │ Port │ TCP │ UDP ┃
-┠──────────────────────────────────────────────────────────────────┼────────────────────────────┼──────┼─────┼─────┨
-┃ a8a2d6ad3858e1eedc985d89c33ab6898babe6ae5d68ce3cdafc78d20dbe4cd8 │ test olivier c             │ 22   │ +   │ -   ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━┷━━━━━┷━━━━━┛
-╔══════════════════ Port Forward Info ══════════════════╗
-║                                                       ║
-║  Address: 0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90  ║
-║                                                       ║
-╚═══════════════════════════════════════════════════════╝
+Filter by VM using `--vm-id`:
+
+```bash
+aleph instance port-forward list --vm-id <VM_ID>
 ```
+
+```text
+$ aleph instance pfw list --address my-account
+ITEM_HASH      PORT  EXTERNAL_PORT    TCP    UDP
+a8a2d6ad3858     22          27042   true  false
+a8a2d6ad3858   8080          27043   true   true
+b3f1c4e29d77     22            N/A   true  false
+```
+
+`ITEM_HASH` is truncated to its 12-character prefix (the same shorthand `aleph instance list` shows). `EXTERNAL_PORT` is `N/A` until the CRN assigns one. `--address` accepts a raw address, a local account name, or an alias.
 
 ### More information
 
 More help is available from the aleph command online help system which can be invoked via:
 
 ```bash
-aleph instance port-forwarder --help
+aleph instance port-forward --help
 ```


### PR DESCRIPTION
## Summary

Part of the Python→Rust CLI docs migration (Task 5).

- **custom-domains/instance.md**: replaced `aleph-client` install link with the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) page; updated `aleph domain add` example to use verified `--target <HASH> --kind instance <DOMAIN>` syntax; updated `aleph domain attach` example to use verified `--to <TARGET> <DOMAIN>` syntax; added note about `--on-behalf-of` for delegated updates.
- **ipv4/ipv4-port-forwarding.md**: renamed `port-forwarder` → `port-forward` (alias `pfw`) throughout; fixed `create` to use positional `<VM_ID> <PORT>` with `--tcp true|false` / `--udp true|false`; fixed `refresh` to take positional `<VM_ID>`; fixed `list` to use `--vm-id` (not `--item-hash`); all flags verified against `aleph instance port-forward <sub> --help`.

## Test plan

- [x] `npm run docs:build` completes with `build complete`
- [x] `grep -rnE "aleph-client|port-forwarder|--no-tcp|--no-udp|--item-hash" <files>` returns nothing
- [x] All flag spellings verified against binary at `/home/olivier/git/aleph/aleph-rs/target/debug/aleph` (v0.10.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)