### PR TITLE
docs(confidential): migrate confidential instance pages to the Rust CLI

### DIFF
--- a/docs/devhub/compute-resources/confidential-instances/01-confidential-instance-introduction.md
+++ b/docs/devhub/compute-resources/confidential-instances/01-confidential-instance-introduction.md
@@ -45,7 +45,7 @@ To create a confidential virtual machine, you'll need:
 
 - A Linux system on x86_64 architecture (not Mac) with IPv6 connectivity
 - The following software installed:
-  - [aleph-client](/devhub/sdks-and-tools/aleph-cli/) command-line tool
+  - [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) command-line tool
   - [sevctl](https://github.com/virtee/sevctl) tool from AMD
   - An OpenSSH keypair
   - An IPFS Server

--- a/docs/devhub/compute-resources/confidential-instances/02-confidential-instance-requirements.md
+++ b/docs/devhub/compute-resources/confidential-instances/02-confidential-instance-requirements.md
@@ -20,15 +20,24 @@ This requirement will be lifted in the future with confidential virtual machines
 
 To create and deploy confidential virtual machines, you'll need the following software:
 
-### 1. aleph-client
+### 1. Aleph CLI
 
-The `aleph-client` command-line tool is used to interact with the Aleph Cloud network. Install it using:
+The [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) is used to interact with the Aleph Cloud network. Install it using one of the following methods:
 
-```bash
-pip install aleph-client
+::: code-group
+```sh [macOS]
+brew install aleph-im/homebrew-tap/aleph-cli
 ```
+```sh [Linux (Debian/Ubuntu)]
+curl -fsSL https://apt.aleph.im/install.sh | sudo bash
+sudo apt install aleph-cli
+```
+```sh [Cargo (any platform)]
+cargo install aleph-cli
+```
+:::
 
-For detailed installation instructions, see the [aleph-client documentation](/devhub/sdks-and-tools/aleph-cli/).
+For detailed installation instructions, see the [Aleph CLI documentation](/devhub/sdks-and-tools/aleph-cli/).
 
 ### 2. sevctl
 

--- a/docs/devhub/compute-resources/confidential-instances/03-confidential-instance-create-encrypted-disk.md
+++ b/docs/devhub/compute-resources/confidential-instances/03-confidential-instance-create-encrypted-disk.md
@@ -150,7 +150,7 @@ This will return an IPFS hash that you'll need for the next step.
 
 ### 8. Register the Disk Image on Aleph Cloud
 
-Pin the IPFS file on Aleph Cloud using the aleph-client:
+Pin the IPFS file on Aleph Cloud using the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/):
 
 ```bash
 aleph file pin <ipfs-hash>

--- a/docs/devhub/compute-resources/confidential-instances/04-confidential-instance-deploy.md
+++ b/docs/devhub/compute-resources/confidential-instances/04-confidential-instance-deploy.md
@@ -6,7 +6,7 @@ This guide walks you through the process of deploying a confidential virtual mac
 
 Before proceeding, ensure you have:
 
-1. Installed the required tools (`aleph-client` and `sevctl`) as outlined in the [Requirements](/devhub/compute-resources/confidential-instances/02-confidential-instance-requirements) guide
+1. Installed the required tools (the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) and `sevctl`) as outlined in the [Requirements](/devhub/compute-resources/confidential-instances/02-confidential-instance-requirements) guide
 2. Created and uploaded an encrypted VM image following the [Encrypted Disk Image](/devhub/compute-resources/confidential-instances/03-confidential-instance-create-encrypted-disk) guide
 3. The ItemHash of your encrypted disk image (obtained from `aleph file list`)
 4. ALEPH tokens for payment (either for staking or streaming payments)
@@ -20,25 +20,23 @@ There are two methods to deploy a confidential instance on Aleph Cloud:
 
 ## Method 1: Automatic Instance Creation
 
-The CLI provides a streamlined command to automate the entire creation process:
+In v0.11.1 the streamlined flow is two steps. First allocate the VM:
 
 ```bash
-aleph instance confidential
+aleph instance create --confidential [OPTIONS] <NAME>
 ```
 
-This interactive command will guide you through the process and handle:
+Then run the all-in-one confidential setup, passing the VM hash from the previous step:
 
-- Instance creation
-- Secure channel setup
-- VM initialization with your encryption password
+```bash
+aleph instance confidential create <vm-hash>
+```
 
-Follow the prompts to:
+`confidential create <vm-hash>` handles the remaining workflow in one shot: it initializes the secure session, validates the launch measurement, and injects the disk-decryption secret.
 
-- Select a payment method
-- Specify resource requirements
-- Choose your encrypted disk image
-- Enter your disk encryption password
-- Select a deployment node
+::: info Not yet available
+The fully-automatic no-argument form (`aleph instance confidential create` without a VM hash) is not yet implemented in v0.11.1. Use the two-step flow above, or follow the Manual Method below for the full step-by-step walkthrough.
+:::
 
 ## Method 2: Manual Instance Creation
 
@@ -52,14 +50,20 @@ Launch the instance configuration process:
 aleph instance create --confidential
 ```
 
-During this process, you'll need to specify:
+In interactive mode (`-i`), you will be prompted for:
 
-- **Payment**: Select a payment chain (Ethereum, Avalanche, etc.) and payment method (hold, superfluid, credit)
-- **Resources**: Specify CPU cores, RAM amount, disk size, and rootfs (your VM image hash)
-- **Deployment**: Choose a Compute Resource Node (CRN) for deployment
+- **Image**: a preset name (`ubuntu22`, `ubuntu24`, `debian12`) or an item hash / IPFS CID (`--image`)
+- **Size**: a slug like `1vcpu-2gb` or `4vcpu-8gb`, or custom sizing via `--vcpus`, `--memory`, `--disk-size` (`--size`)
+- **SSH key**: path to your SSH public key file (`--ssh-pubkey-file`)
+- **CRN**: the interactive flow lets you pick a Compute Resource Node; pin to a specific one with `--crn-hash <HASH>`
+- **Volumes** (optional): persistent, ephemeral, or immutable volumes (`--persistent-volume`, `--ephemeral-volume`, `--immutable-volume`)
+- **Confidential firmware** (optional): UEFI firmware preset or hash (`--confidential-firmware`; defaults to the active firmware from the `vm-images` aggregate)
+
+Payment is handled via credits by default; no payment-chain selection is required.
 
 ::: warning Important
-Record the CRN URL and VM hash displayed after creation. You'll need these for subsequent steps.
+Record the VM hash displayed after creation. You will need it for the subsequent steps.
+If you lose it, run `aleph instance list` to recover it.
 :::
 
 If you forget these details, you can retrieve them using:
@@ -73,7 +77,7 @@ aleph instance list
 Initialize a secure session with your VM:
 
 ```bash
-aleph instance confidential-init-session <vm-hash>
+aleph instance confidential init-session <vm-hash>
 ```
 
 Replace `<vm-hash>` with the hash of your VM instance.
@@ -82,8 +86,10 @@ Replace `<vm-hash>` with the hash of your VM instance.
 If this step fails, try rebooting the instance:
 
 ```bash
-aleph instance reboot <vm-hash> <node-url>
+aleph instance reboot <vm-hash>
 ```
+
+The scheduler resolves the CRN automatically. If you need to target a specific node, add `--crn <hash-or-url>`.
 
 Then retry establishing the session.
 :::
@@ -93,10 +99,10 @@ Then retry establishing the session.
 Verify the VM's integrity and start it with your encryption password:
 
 ```bash
-aleph instance confidential-start <vm-hash>
+aleph instance confidential start <vm-hash>
 ```
 
-You'll be prompted to enter the encryption password you used when creating the disk image.
+You'll be prompted to enter the encryption password you used when creating the disk image (passed as the `--secret` flag or interactively). Additional attestation flags include `--firmware-hash <HEX>` to pin the expected OVMF firmware hash, and `--firmware-file <PATH>` to compute the hash from a local firmware blob.
 
 ::: tip Troubleshooting
 If this step fails, try rebooting the instance again and retry.
@@ -145,14 +151,16 @@ Default users depend on the base image you used:
 To stop your instance:
 
 ```bash
-aleph instance stop <vm-hash> <node-url>
+aleph instance stop <vm-hash>
 ```
 
 To reboot your instance:
 
 ```bash
-aleph instance reboot <vm-hash> <node-url>
+aleph instance reboot <vm-hash>
 ```
+
+The CRN is discovered automatically via the scheduler. Pass `--crn <hash-or-url>` if you need to target a specific node.
 
 ## Verifying Confidentiality
 

--- a/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
+++ b/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
@@ -88,14 +88,16 @@ If you're unable to connect to your VM via SSH:
 If you entered the wrong decryption password while starting the VM, you need to reboot it:
 
 ```bash
-aleph instance reboot <vm_hash> <node_url>
+aleph instance reboot <vm_hash>
 ```
+
+The CRN is discovered automatically. Pass `--crn <hash-or-url>` if you need to target a specific node.
 
 Then restart the confidential initialization process:
 
 ```bash
-aleph instance confidential-init-session <vm_hash>
-aleph instance confidential-start <vm_hash>
+aleph instance confidential init-session <vm_hash>
+aleph instance confidential start <vm_hash>
 ```
 
 ### "Bad Measurement" Error
@@ -124,13 +126,13 @@ qemu-system-x86_64: failed to initialize kvm: Operation not permitted
 1. **Regenerate the Session Certificate**
 
    ```bash
-   aleph instance confidential-init-session <vm_hash>
+   aleph instance confidential init-session <vm_hash>
    ```
 
    When prompted to remove existing certificates, answer "yes." Then continue with:
 
    ```bash
-   aleph instance confidential-start <vm_hash>
+   aleph instance confidential start <vm_hash>
    ```
 
 2. **If the Error Persists**  
@@ -194,7 +196,7 @@ You should see output indicating that AMD SEV is active.
 For more verbose output during session initialization:
 
 ```bash
-aleph instance confidential-init-session <vm_hash> --debug
+aleph instance confidential init-session <vm_hash> --debug
 ```
 
 ### Getting Help


### PR DESCRIPTION
Part of the Python to Rust CLI docs migration. Migrates the 5 confidential-instances pages to aleph-rs v0.11.1: instance confidential-init-session/-start become instance confidential init-session/start (subcommand group); aleph instance reboot/stop drop the trailing node_url positional (use --crn flag if overriding the scheduler); install lines updated.