### PR TITLE
Clean up community and social links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Brief description of your changes.
 
 - **Questions about contributing:** Open a [GitHub Discussion](https://github.com/aleph-im/aleph-cloud-docs/discussions)
 - **Found a bug:** Open a [GitHub Issue](https://github.com/aleph-im/aleph-cloud-docs/issues)
-- **Community chat:** Join us on [Telegram](https://t.me/alaboratory)
+- **Community chat:** Join us on [Telegram](https://t.me/alephcloud)
 
 ## Code of Conduct
 

--- a/docs/about/resources/community/index.md
+++ b/docs/about/resources/community/index.md
@@ -6,20 +6,19 @@ The Aleph Cloud community is active across various platforms. This page provides
 
 ### Social Media
 
-- [Twitter](https://twitter.com/aleph_im)
-- [LinkedIn](https://www.linkedin.com/company/aleph-im/)
-- [YouTube](https://www.youtube.com/@aleph_im)
+- [X / Twitter](https://x.com/aleph_im)
+- [LinkedIn](https://www.linkedin.com/company/aleph-cloud)
+- [YouTube](https://www.youtube.com/@alephcloud)
 
 ### Discussion Forums
 
 - [Telegram Group](https://t.me/alephcloud) - Main community chat
 - [Discourse Forum](https://community.aleph.cloud/) - Technical discussions and announcements
-- [Discord Server](https://discord.com/invite/alephcloud) - Developer community
 
 ## Support
 
 - [GitHub Issues](https://github.com/aleph-im/support/issues) - Report bugs or request features
-- [Support Email](mailto:hello@aleph.im) - Direct support from the Aleph Cloud team
+- [Support Email](mailto:hello@aleph.cloud) - Direct support from the Aleph Cloud team
 
 ## Developer Resources
 
@@ -35,13 +34,13 @@ The Aleph Cloud community is active across various platforms. This page provides
 ## Events
 
 - [Upcoming Events](https://lu.ma/aleph-im) - Conferences, hackathons, and meetups
-- <a href="https://link" style="color: #ff6666;">Past Events</a> - Recordings of previous presentations
+- [Past Events](https://lu.ma/aleph-im) - Recordings of previous presentations
 
 ## Educational Resources
 
 - [Blog](https://www.aleph.cloud/blog/) - Articles and updates from the Aleph Cloud team
 - [Case Studies](https://www.aleph.cloud/blog/articles/champions-tactics-aleph-vrf/) - Examples of Aleph Cloud in production
-- <a href="https://link" style="color: #ff6666;">Tutorials</a> - Step-by-step guides for developers
+- [Tutorials](/devhub/) - Step-by-step guides for developers
 
 ## Getting Involved
 

--- a/docs/about/resources/faq/index.md
+++ b/docs/about/resources/faq/index.md
@@ -7,8 +7,8 @@
 - Web: [https://aleph.cloud](https://aleph.cloud)
 - Forum: [https://community.aleph.cloud](https://community.aleph.cloud)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
-- Twitter: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
-- Linkedin: [https://www.linkedin.com/company/aleph-im](https://www.linkedin.com/company/aleph-im)
+- X / Twitter: [https://x.com/aleph_im](https://x.com/aleph_im)
+- LinkedIn: [https://www.linkedin.com/company/aleph-cloud](https://www.linkedin.com/company/aleph-cloud)
 - Telegram: [https://t.me/alephcloud](https://t.me/alephcloud)
 
 ### $ALEPH Token Contracts/Mint addresses

--- a/docs/devhub/building-applications/blockchain-data/indexing/evm-indexer.md
+++ b/docs/devhub/building-applications/blockchain-data/indexing/evm-indexer.md
@@ -624,7 +624,7 @@ This guide has walked you through setting up an indexer for the ethereum blockch
 
 ### 10.2 Social
 
-- X aleph.cloud: [https://twitter.com/aleph_im](https://twitter.com/aleph_cloud)
+- X aleph.cloud: [https://x.com/aleph_im](https://x.com/aleph_im)
 - Community: [https://t.me/alephcloud](https://t.me/alephcloud)
 - Medium: [https://medium.com/aleph-im](https://medium.com/aleph-im)
 

--- a/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
+++ b/docs/devhub/compute-resources/confidential-instances/05-confidential-instance-troubleshooting.md
@@ -201,6 +201,6 @@ aleph instance confidential-init-session <vm_hash> --debug
 
 If you've tried the solutions above and are still experiencing issues:
 
-1. Join the [Aleph Cloud Discord](https://discord.com/invite/alephcloud) for community support
+1. Join the [Aleph Cloud Telegram](https://t.me/alephcloud) for community support
 2. Open an issue on the [Aleph-VM GitHub repository](https://github.com/aleph-im/aleph-vm/issues)
 3. Contact the Aleph Cloud team directly through the [official website](https://aleph.cloud/contact)

--- a/docs/devhub/faq/index.md
+++ b/docs/devhub/faq/index.md
@@ -7,8 +7,8 @@
 - Web: [https://aleph.cloud](https://aleph.cloud)
 - Forum: [https://community.aleph.cloud](https://community.aleph.cloud)
 - Github: [https://github.com/aleph-im](https://github.com/aleph-im)
-- Twitter: [https://twitter.com/aleph_im](https://twitter.com/aleph_im)
-- Linkedin: [https://www.linkedin.com/company/aleph-im](https://www.linkedin.com/company/aleph-im)
+- X / Twitter: [https://x.com/aleph_im](https://x.com/aleph_im)
+- LinkedIn: [https://www.linkedin.com/company/aleph-cloud](https://www.linkedin.com/company/aleph-cloud)
 - Telegram: [https://t.me/alephcloud](https://t.me/alephcloud)
 
 ### $ALEPH Token Contracts/Mint addresses

--- a/docs/devhub/getting-started/index.md
+++ b/docs/devhub/getting-started/index.md
@@ -153,7 +153,7 @@ To help you get started, we've prepared some sample projects:
 
 1. Explore the [SDK documentation](/devhub/sdks-and-tools/typescript-sdk/) for your preferred language
 2. Check out the [API Reference](/devhub/api/rest) for detailed endpoint information
-3. Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) to connect with the community
+3. Join the [Aleph Cloud Telegram](https://t.me/alephcloud) to connect with the community
 4. Browse [example projects](/devhub/examples/) for inspiration
 
 ## Getting Help
@@ -161,6 +161,6 @@ To help you get started, we've prepared some sample projects:
 If you encounter any issues or have questions:
 
 - Check the documentation for your specific use case
-- Join the [Aleph Cloud Discord](https://discord.gg/alephcloud) for community support
+- Join the [Aleph Cloud Telegram](https://t.me/alephcloud) for community support
 - Visit the [Aleph Cloud GitHub](https://github.com/aleph-im) to report issues or contribute
 - Contact the Aleph Cloud team through the [official website](https://aleph.cloud/contact)

--- a/docs/devhub/index.md
+++ b/docs/devhub/index.md
@@ -47,9 +47,9 @@ Get inspired by real-world examples:
 
 Join our developer community:
 
-- [Discord](https://discord.com/invite/alephcloud) - Connect with other developers and get support
+- [Telegram](https://t.me/alephcloud) - Connect with other developers and get support
 - [GitHub](https://github.com/aleph-im) - Explore our open-source repositories
-- [Forum](https://forum.aleph.cloud) - Discuss technical topics and proposals
+- [Forum](https://community.aleph.cloud/) - Discuss technical topics and proposals
 
 ## Contribute
 

--- a/docs/devhub/storage/ipfs-pinning/index.md
+++ b/docs/devhub/storage/ipfs-pinning/index.md
@@ -188,7 +188,7 @@ export default async function (req, context) {
 If you encounter issues with IPFS pinning:
 
 1. Check the [Aleph Cloud documentation](/devhub/)
-2. Join the [Aleph Cloud Discord](https://discord.com/invite/alephcloud) for community support
+2. Join the [Aleph Cloud Telegram](https://t.me/alephcloud) for community support
 3. Contact support through the [Aleph Cloud website](https://aleph.cloud/contact)
 
 ## Next Steps

--- a/docs/nodes/core/troubleshooting/index.md
+++ b/docs/nodes/core/troubleshooting/index.md
@@ -357,5 +357,5 @@ Your node can't connect to the configured Ethereum API endpoint.
 
 If you're still experiencing issues after trying these troubleshooting steps:
 
-1. Visit the [Aleph.im Community](https://discord.gg/aleph-im) on Discord
+1. Visit the [Aleph Cloud community forum](https://community.aleph.cloud/) for community support
 2. Review the [Node Monitoring](/nodes/resources/management/monitoring/) documentation for additional diagnostic tools

--- a/docs/nodes/resources/releases/index.md
+++ b/docs/nodes/resources/releases/index.md
@@ -43,6 +43,6 @@ _aleph-vm_ is published in two formats:
 4. Draft release notes are prepared on the GitHub releases page.
 5. Packages are downloaded, unpacked, and attached to the release.
 6. Release notes are reviewed and published.
-7. The release is announced on [Twitter](https://twitter.com/aleph_im), [Telegram](https://t.me/alephcloud), and other channels.
+7. The release is announced on [X / Twitter](https://x.com/aleph_im), [Telegram](https://t.me/alephcloud), and other channels.
 
 All releases are documented on the [_aleph-vm_ GitHub releases page](https://github.com/aleph-im/aleph-vm/releases).


### PR DESCRIPTION
## Summary
- update docs community/social links to current Aleph Cloud channels
- remove Discord as a public docs target while it is outdated
- replace stale forum, Telegram, LinkedIn, YouTube, and X/Twitter references
- remove placeholder community resource links

## Verification
- rg scan for stale Discord, old YouTube, old LinkedIn, old Twitter, old forum, placeholder, and old support-email patterns
- git diff --check

Full Node docs build was not run because dependencies are not installed locally.