### PR TITLE
docs(cli): fix review findings from Rust CLI migration

### DIFF
--- a/docs/about/how-it-works/index.md
+++ b/docs/about/how-it-works/index.md
@@ -12,7 +12,7 @@ The Aleph Cloud network is composed of 2 sets of nodes:
 ## Messages
 
 In Aleph Cloud terminology, a "_message_" is similar to a "_transaction_" for a blockchain: it is a set of data sent by an end user, propagated through the entire peer-to-peer network.
-A message can be generated using either the [Python SDK](/devhub/sdks-and-tools/python-sdk/) or [TypeScript SDK](/devhub/sdks-and-tools/typescript-sdk/), or through [aleph-client](/devhub/sdks-and-tools/aleph-cli/) or the [Web Console](https://app.aleph.cloud).
+A message can be generated using either the [Python SDK](/devhub/sdks-and-tools/python-sdk/) or [TypeScript SDK](/devhub/sdks-and-tools/typescript-sdk/), or through the [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/) or the [Web Console](https://app.aleph.cloud).
 
 These messages can contain several different instructions, such as reading or writing posts, programs/functions, or indexing data created on external blockchains.
 

--- a/docs/devhub/compute-resources/confidential-instances/04-confidential-instance-deploy.md
+++ b/docs/devhub/compute-resources/confidential-instances/04-confidential-instance-deploy.md
@@ -47,12 +47,12 @@ For more control over the deployment process, follow these steps:
 Launch the instance configuration process:
 
 ```bash
-aleph instance create --confidential
+aleph instance create --confidential <NAME>
 ```
 
 In interactive mode (`-i`), you will be prompted for:
 
-- **Image**: a preset name (`ubuntu22`, `ubuntu24`, `debian12`) or an item hash / IPFS CID (`--image`)
+- **Image**: a preset name (`ubuntu22`, `ubuntu24`, `ubuntu26`, `debian12`) or an item hash / IPFS CID (`--image`)
 - **Size**: a slug like `1vcpu-2gb` or `4vcpu-8gb`, or custom sizing via `--vcpus`, `--memory`, `--disk-size` (`--size`)
 - **SSH key**: path to your SSH public key file (`--ssh-pubkey-file`)
 - **CRN**: the interactive flow lets you pick a Compute Resource Node; pin to a specific one with `--crn-hash <HASH>`

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/dependency-volumes.md
@@ -72,31 +72,16 @@ aleph file pin QmWWX6BaaRkRSr2iNdwH5e29ACPg2nCHHXTRTfuBmVm3Ga
 
 ## Create your program
 
-```shell
-aleph program create ./my-program main:app
-```
-
-Press Enter at the following prompt to use the default runtime:
-
-```
-Ref of runtime ? [63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696]
-```
-
-Press `Y` to add extra volumes to your program:
-
-```
-Add volume ? [y/N] Y
-Description: Python Packages
-Mount: /opt/packages
-Ref: 61f43ab261060ff94838dc94313a70cdb939a5fc6c99924b96d55dcc2c108d03
-Use latest version ? [Y/n] Y
-```
-
-Finally, press Enter to skip adding more volumes.
+Attach the dependency volume with the `--immutable-volume` option, using the item hash of the
+uploaded volume as `ref` and the directory where it should be mounted as `mount`:
 
 ```shell
-Add volume ? [y/N]
+aleph program create ./my-program main:app \
+  --immutable-volume ref=61f43ab261060ff94838dc94313a70cdb939a5fc6c99924b96d55dcc2c108d03,mount=/opt/packages,use_latest=true
 ```
+
+When `--runtime` is omitted, the network's default runtime is used automatically.
+The `--immutable-volume` option can be repeated to attach more than one volume.
 
 Your program should be uploaded on Aleph Cloud.
 

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/advanced/features.md
@@ -137,7 +137,8 @@ Pin the volume on Aleph Cloud using `aleph file pin`:
 aleph file pin $IPFS_HASH --channel TEST
 ```
 
-Mention the volume in the prompt of `aleph program (...)`
+Attach the volume to your program with the `--immutable-volume` option of `aleph program create`
+(e.g. `--immutable-volume ref=ITEM_HASH,mount=/opt/extra-lib`).
 
 #### 2. Update an immutable volume
 

--- a/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
+++ b/docs/devhub/compute-resources/functions/advanced/custom-builds/python/getting-started/index.md
@@ -184,28 +184,16 @@ This command will upload our Python code and configure `main:app` as the ASGI ap
 aleph program create ./my-program main:app
 ```
 
-Press Enter at the following prompt to use the default runtime:
+The command runs without prompting: when `--runtime` is omitted, the network's default runtime is used automatically.
+The CLI hashes and uploads the code archive, publishes the PROGRAM message, and ends with the URLs where your program is served:
 
 ```
-Ref of runtime ? [63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696]
-```
-
-You should then get a response similar to the following:
-
-```
-Your program has been uploaded on Aleph Cloud .
-
-Available on:
-  https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+Try it at:
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
-Visualise on:
-  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
-You may get the warning `Message failed to publish on IPFS and/or P2P`.
-This is common and usually not an issue.
-
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph Cloud identifiers are too long to work
+> ℹ The first URL uses a hostname dedicated to your VM. Aleph Cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [Custom Domain](/devhub/deploying-and-hosting/custom-domains/setup) section.

--- a/docs/devhub/compute-resources/functions/getting-started.md
+++ b/docs/devhub/compute-resources/functions/getting-started.md
@@ -199,28 +199,16 @@ This command will upload our Python code and configure `main:app` as the ASGI ap
 aleph program create ./my-program main:app
 ```
 
-Press Enter at the following prompt to use the default runtime:
+The command runs without prompting: when `--runtime` is omitted, the network's default runtime is used automatically.
+The CLI hashes and uploads the code archive, publishes the PROGRAM message, and ends with the URLs where your program is served:
 
 ```
-Ref of runtime ? [63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696]
-```
-
-You should then get a response similar to the following:
-
-```
-Your program has been uploaded on aleph.cloud .
-
-Available on:
-  https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+Try it at:
   https://du4ef7cck7ap2t44pvoflo5bmjsn5dke6rzglikpr5xljvkc3wra.aleph.sh
-Visualise on:
-  https://explorer.aleph.cloud/address/ETH/0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9/message/PROGRAM/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
+  https://aleph.sh/vm/1d3842fc4257c0fd4f9c7d5c55bba16264de8d44f47265a14f8f6eb4d542dda2
 ```
 
-You may get the warning `Message failed to publish on IPFS and/or P2P`.
-This is common and usually not an issue.
-
-> ℹ The second URL uses a hostname dedicated to your VM. Aleph.cloud identifiers are too long to work
+> ℹ The first URL uses a hostname dedicated to your VM. Aleph.cloud identifiers are too long to work
 > for URL subdomains, so a base32 encoded version of the identifier is used instead.
 
 > ℹ You can make your own domain point to the VM. See the [advanced](/devhub/deploying-and-hosting/custom-domains/setup) section.

--- a/docs/devhub/deploying-and-hosting/web-hosting/index.md
+++ b/docs/devhub/deploying-and-hosting/web-hosting/index.md
@@ -76,7 +76,7 @@ Find alternative gateways [here](https://ipfs.github.io/public-gateway-checker/)
 
 At deployment time, or later, you can link a custom domain to your website using:
 
-- [Aleph-Client](/devhub/sdks-and-tools/aleph-cli/)
+- [Aleph CLI](/devhub/sdks-and-tools/aleph-cli/)
 - [Aleph Cloud Console](https://app.aleph.cloud/console/hosting/website/new/)
 
 ### ENS Domains

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/instance.md
@@ -78,19 +78,19 @@ aleph instance create [OPTIONS] <NAME>
 ```bash
 # Create a basic instance with a size slug
 aleph instance create web \
-  --image ubuntu24 \
+  --image ubuntu26 \
   --size 1vcpu-2gb \
   --ssh-pubkey-file ~/.ssh/id_ed25519.pub
 
 # Create a GPU instance
 aleph instance create gpu-job \
-  --image ubuntu24 \
+  --image ubuntu26 \
   --gpu h100 \
   --ssh-pubkey-file ~/.ssh/id_ed25519.pub
 
 # Create with custom resources and a persistent volume
 aleph instance create db \
-  --image ubuntu24 \
+  --image ubuntu26 \
   --size 4vcpu-8gb \
   --persistent-volume name=data,mount=/data,size=100GB \
   --ssh-pubkey-file ~/.ssh/id_ed25519.pub
@@ -158,8 +158,6 @@ aleph instance list [OPTIONS]
 |---------------------|----------------------------------------------------|
 | `--address <ADDR>`  | Owner address to list instances for                |
 | `--json`            | Output results as JSON                             |
-| `--account <NAME>`  | Named account (defaults to the active account)     |
-| `--private-key <K>` | Hex-encoded private key                            |
 | `--help`            | Show this message and exit                         |
 
 ```bash
@@ -211,7 +209,7 @@ aleph instance start [OPTIONS] <VM_ID>
 
 | Option                  | Description                                                                       |
 |-------------------------|-----------------------------------------------------------------------------------|
-| `--crn-url <URL>`       | CRN endpoint URL override (bypasses scheduler discovery)                          |
+| `--crn <CRN>`           | CRN to target: node hash, unique prefix/suffix, or URL (bypasses scheduler discovery) |
 | `--json`                | Output results as JSON                                                            |
 | `--account <ACCOUNT>`   | Named account (defaults to the active account)                                    |
 | `--private-key <KEY>`   | Hex-encoded private key                                                           |
@@ -286,7 +284,7 @@ aleph instance ssh [OPTIONS] <VM_ID> [SSH_ARGS]...
 
 | Option                  | Description                                               |
 |-------------------------|-----------------------------------------------------------|
-| `--crn-url <URL>`       | Skip scheduler discovery and connect directly             |
+| `--crn <CRN>`           | CRN to target: node hash or URL (skips scheduler discovery) |
 | `--user <USER>`         | SSH user to connect as [default: root]                    |
 | `--port <PORT>`         | SSH port [default: 22]                                    |
 | `--identity <PATH>`     | Path to an SSH private key (`ssh -i`)                     |

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
@@ -143,8 +143,6 @@ aleph program list [OPTIONS]
 | ------------------- | ---------------------------------------------- |
 | `--address <ADDR>`  | Owner address of the programs                  |
 | `--json`            | Output results as JSON                         |
-| `--account <NAME>`  | Named account (defaults to the active account) |
-| `--private-key <K>` | Hex-encoded private key                        |
 | `--help`            | Show this message and exit                     |
 
 ```bash
@@ -187,17 +185,27 @@ aleph program unpersist ITEM_HASH
 
 ## Display Logs of a Program
 
-Fetch logs from one CRN running this program.
+Fetch logs from one CRN running this program. The `--crn` option is required: pass the URL of the CRN executing the program.
 
 ### Usage
 
 ```bash
-aleph program logs [OPTIONS] <ITEM_HASH>
+aleph program logs --crn <CRN_URL> <ITEM_HASH>
 ```
+
+#### Options
+
+| Option                | Description                                         |
+| --------------------- | --------------------------------------------------- |
+| `--crn <CRN>`         | CRN URL (e.g. `https://crn.example.com`) [required]  |
+| `--account <NAME>`    | Named account (defaults to the active account)      |
+| `--private-key <KEY>` | Hex-encoded private key                             |
+| `--json`              | Output results as JSON                              |
+| `--help`              | Show this message and exit                          |
 
 ```bash
 # Display logs of a program
-aleph program logs ITEM_HASH
+aleph program logs --crn https://crn.example.com ITEM_HASH
 ```
 
 ## Supported Runtimes
@@ -209,6 +217,6 @@ Aleph Cloud supports multiple programming languages. Use a preset slug (e.g. `py
 Common issues and solutions:
 
 - **Deployment failures**: Check your code for errors and ensure all dependencies are specified
-- **Runtime errors**: View logs with `aleph program logs PROGRAM_HASH`
+- **Runtime errors**: View logs with `aleph program logs --crn CRN_URL PROGRAM_HASH`
 - **Resource limitations**: Increase memory or CPU if your function is resource-intensive
 - **Timeout issues**: Optimize your code or increase the function timeout setting

--- a/docs/devhub/storage/ipfs-pinning/index.md
+++ b/docs/devhub/storage/ipfs-pinning/index.md
@@ -32,8 +32,8 @@ The simplest way to pin content is using the Aleph CLI. Install the [Aleph CLI](
 aleph file pin QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
 
 # Pin a local file (uploads and pins)
-# file > 4MB goes to ipfs other goes to storage engine
-aleph file upload myfile.txt
+# Files use native storage by default; pass --storage-engine ipfs to pin on IPFS
+aleph file upload myfile.txt --storage-engine ipfs
 ```
 
 #### Using the JavaScript SDK
@@ -95,7 +95,7 @@ curl "https://api.aleph.im/api/v0/addresses/{address}/files"
 
 ```bash
 # Using the CLI
-aleph file delete item_hash1 item_hash2 # item hash of the store message not Ipfs CID / File hash
+aleph file delete file_hash1 file_hash2 # file content hash (IPFS CID or native hex), not the STORE message hash
 
 ```
 


### PR DESCRIPTION
Post-migration review of dev-rust-cli against the aleph-rs v0.11.1 binary and the live vm-images/pricing aggregates. Fixes everything that was broken or still carried Python CLI behavior.

## Broken commands fixed
- **instance.md**: \`--crn-url\` in the \`start\` and \`ssh\` option tables renamed to the real \`--crn <CRN>\` flag; removed \`--account\`/\`--private-key\` from the \`instance list\` table (the subcommand only has \`--address\` and \`--json\`)
- **program.md**: same phantom flags removed from \`program list\`; \`program logs\` now documents the required \`--crn <CRN_URL>\` option (the previous example failed with a missing-argument error)
- **dependency-volumes.md**: replaced the Python CLI interactive walkthrough (\`Ref of runtime ?\`, \`Add volume ? [y/N]\`...) with the non-interactive \`--immutable-volume ref=...,mount=...\` flow

## Leftover Python CLI behavior fixed
- **functions/getting-started.md** + **custom-builds/python/getting-started**: removed the runtime prompt instructions, the \`Available on:/Visualise on:\` output and the IPFS/P2P warning; replaced with the actual \`Try it at:\` output
- **features.md**: "mention the volume in the prompt" replaced with \`--immutable-volume\`
- **ipfs-pinning**: fixed the storage engine comment (no 4 MB IPFS threshold; native storage is the default for files) and the \`file delete\` comment (takes file content hashes, not STORE message hashes)
- **confidential deploy**: added the required \`<NAME>\` positional to the manual create step, added \`ubuntu26\` to the preset list
- **instance.md examples**: \`--image ubuntu24\` switched to \`ubuntu26\` (the network default)
- Renamed two leftover "aleph-client" mentions (web-hosting, how-it-works) to "Aleph CLI"

## Verified, not changed
- \`ubuntu26\` and \`python3.12\` are correct per the live vm-images aggregate (both are the network defaults). The aleph-rs \`--help\` text is stale on both counts; worth an upstream issue.
- pricing.md GPU table (\`h200\` etc.) matches the live pricing aggregate.

Build passes with \`npx vitepress build docs\`.