### PR TITLE
docs: replace em-dashes with hyphens

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,9 +21,9 @@ Technical patterns and decisions.
 | `docs/.vitepress/` | VitePress config, theme customizations, build output |
 | `docs/.vitepress/theme/` | Custom Vue components and CSS overrides |
 | `docs/assets/images/` | All images, organized by topic subdirectory |
-| `docs/about/` | About Aleph Cloud — overview, network, use cases |
-| `docs/nodes/` | Node operator guides — setup, staking, resources |
-| `docs/devhub/` | Developer hub — SDKs, APIs, tutorials, examples |
+| `docs/about/` | About Aleph Cloud - overview, network, use cases |
+| `docs/nodes/` | Node operator guides - setup, staking, resources |
+| `docs/devhub/` | Developer hub - SDKs, APIs, tutorials, examples |
 | `docs/plans/` | Design and implementation plans (read-only reference) |
 | `scripts/` | Build-time scripts (version, links, deploy) |
 
@@ -33,9 +33,9 @@ Technical patterns and decisions.
 
 The production build runs three stages in sequence:
 
-1. **`scripts/links.js --prompt`** — Scans all markdown for broken internal links and missing images. Halts the build (or prompts) if any are found.
-2. **`scripts/version.js`** — Writes the current git commit hash and version to `docs/.vitepress/version.json` and `docs/public/version.json` for the footer display.
-3. **`vitepress build docs`** — Compiles the site to `docs/.vitepress/dist/`.
+1. **`scripts/links.js --prompt`** - Scans all markdown for broken internal links and missing images. Halts the build (or prompts) if any are found.
+2. **`scripts/version.js`** - Writes the current git commit hash and version to `docs/.vitepress/version.json` and `docs/public/version.json` for the footer display.
+3. **`vitepress build docs`** - Compiles the site to `docs/.vitepress/dist/`.
 
 Local dev (`npm run docs:dev`) skips link checking and only runs version + VitePress dev server.
 

--- a/docs/about/use-cases/index.md
+++ b/docs/about/use-cases/index.md
@@ -16,7 +16,7 @@ Aleph Cloud provides decentralized infrastructure for a wide range of applicatio
     </div>
     <div class="vp-card-content">
       <h3>Ubisoft - Champions Tactics</h3>
-      <p>AAleph Cloud partnered with Ubisoft’s Innovation Lab to power dynamic NFTs in "Champions Tactics: Grimoria Chronicles." With Aleph Cloud’s decentralized tech, each Champion NFT has unique, updatable metadata—letting players own, use, and trade evolving assets in a secure blockchain ecosystem.</p>
+      <p>Aleph Cloud partnered with Ubisoft’s Innovation Lab to power dynamic NFTs in "Champions Tactics: Grimoria Chronicles." With Aleph Cloud’s decentralized tech, each Champion NFT has unique, updatable metadata - letting players own, use, and trade evolving assets in a secure blockchain ecosystem.</p>
       <ActionButtons>
         <ActionButton theme="alt" text="Learn more →" link="https://aleph.cloud/blog/articles/champions-tactics-aleph-vrf/" />
       </ActionButtons>
@@ -29,7 +29,7 @@ Aleph Cloud provides decentralized infrastructure for a wide range of applicatio
     </div>
     <div class="vp-card-content">
       <h3>Ubisoft - Captain Laserhawk</h3>
-      <p>Aleph Cloud partnered with Ubisoft to enable dynamic NFTs in "Captain Laserhawk: The G.A.M.E". With Aleph Cloud’s decentralized infrastructure, NFT metadata can update in real time—so in-game assets evolve, reflect achievements, and connect to external data. This gives players interactive digital collectibles beyond static NFTs.</p>
+      <p>Aleph Cloud partnered with Ubisoft to enable dynamic NFTs in "Captain Laserhawk: The G.A.M.E". With Aleph Cloud’s decentralized infrastructure, NFT metadata can update in real time - so in-game assets evolve, reflect achievements, and connect to external data. This gives players interactive digital collectibles beyond static NFTs.</p>
       <ActionButtons>
         <ActionButton theme="alt" text="Learn more →" link="https://aleph.cloud/blog/articles/ubisoft-captain-laserhawk-dynamic-nfts/" />
       </ActionButtons>

--- a/docs/devhub/deploying-and-hosting/automatic-domains/index.md
+++ b/docs/devhub/deploying-and-hosting/automatic-domains/index.md
@@ -1,6 +1,6 @@
 # Automatic Domains (2n6.me)
 
-Every Aleph Cloud instance automatically receives a free, deterministic URL under `*.2n6.me`. These URLs are derived from the instance hash — no DNS setup or configuration is required.
+Every Aleph Cloud instance automatically receives a free, deterministic URL under `*.2n6.me`. These URLs are derived from the instance hash - no DNS setup or configuration is required.
 
 Each URL is composed of four memorable [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) words, for example:
 
@@ -85,13 +85,13 @@ Since it's deterministic, you can compute the URL before deploying, or use it in
 
 ### HTTPS (SNI Passthrough)
 
-The 2n6.me gateway performs **Layer 4 SNI passthrough** — it routes TLS connections to your VM based on the Server Name Indication (SNI) in the TLS handshake, without terminating TLS itself.
+The 2n6.me gateway performs **Layer 4 SNI passthrough** - it routes TLS connections to your VM based on the Server Name Indication (SNI) in the TLS handshake, without terminating TLS itself.
 
 ::: warning
 Your VM must serve its own TLS certificate. The gateway does not terminate TLS for you.
 :::
 
-The easiest way to handle this is to run a reverse proxy inside your VM that provides automatic TLS. [Caddy](https://caddyserver.com/) is recommended — it obtains and renews Let's Encrypt certificates automatically with zero configuration:
+The easiest way to handle this is to run a reverse proxy inside your VM that provides automatic TLS. [Caddy](https://caddyserver.com/) is recommended - it obtains and renews Let's Encrypt certificates automatically with zero configuration:
 
 ```bash
 # Inside your VM
@@ -115,7 +115,7 @@ New instances may take up to 5 minutes to become reachable via their 2n6.me URL.
 | DNS setup required | No                                       | Yes (CNAME + TXT records)                                              |
 | URL format         | `word-word-word-word.2n6.me`             | `yourdomain.com`                                                       |
 | Custom branding    | No                                       | Yes                                                                    |
-| TLS handling       | SNI passthrough — VM serves its own cert | SNI passthrough — VM serves its own cert                               |
+| TLS handling       | SNI passthrough - VM serves its own cert | SNI passthrough - VM serves its own cert                               |
 | IPv4               | Yes (proxied via gateway)                | Yes (proxied via CRN)                                                  |
 | IPv6               | Proxied via gateway                      | Direct to VM (no proxy)                                                |
 | SSH access         | No                                       | Yes (custom port on IPv4, direct port 22 on IPv6)                      |
@@ -136,9 +136,9 @@ The subdomain is derived from the instance hash as follows:
 
 **Properties:**
 
-- **Deterministic** — the same hash always produces the same subdomain.
-- **Address space** — 2^44 ≈ 17.6 trillion possible subdomains.
-- **Collision handling** — if two hashes map to the same 44-bit prefix (extremely unlikely), the earlier instance (by timestamp) wins.
+- **Deterministic** - the same hash always produces the same subdomain.
+- **Address space** - 2^44 ≈ 17.6 trillion possible subdomains.
+- **Collision handling** - if two hashes map to the same 44-bit prefix (extremely unlikely), the earlier instance (by timestamp) wins.
 
 ### API Reference
 

--- a/docs/devhub/examples/aggregates-cookbook.md
+++ b/docs/devhub/examples/aggregates-cookbook.md
@@ -4,10 +4,10 @@ Aggregates are key-value pairs stored on the Aleph network, associated with a wa
 
 ## Why Aggregates?
 
-- **No backend required** — data lives on the decentralized network
-- **Wallet-native** — data is tied to addresses, perfect for wallet-based auth
-- **Free reads** — fetching data requires no signature
-- **Signed writes** — storing data proves ownership via wallet signature
+- **No backend required** - data lives on the decentralized network
+- **Wallet-native** - data is tied to addresses, perfect for wallet-based auth
+- **Free reads** - fetching data requires no signature
+- **Signed writes** - storing data proves ownership via wallet signature
 
 ## What We'll Build
 
@@ -87,9 +87,9 @@ export const ETH_MAINNET_CHAIN_ID = '0x1'
 
 ### Key Concepts
 
-- **Channel** — Groups all your app's data together. Use a unique name for your app.
-- **Aggregate key** — Identifies what type of data you're storing. One address can have multiple keys.
-- **Chain ID** — Signatures must happen on Ethereum mainnet.
+- **Channel** - Groups all your app's data together. Use a unique name for your app.
+- **Aggregate key** - Identifies what type of data you're storing. One address can have multiple keys.
+- **Chain ID** - Signatures must happen on Ethereum mainnet.
 
 ## Reading Data
 
@@ -131,8 +131,8 @@ export async function fetchProfile(address: string): Promise<ProfileData | null>
 
 ### Key Points
 
-- `AlephHttpClient` — Unauthenticated, for read-only operations
-- `fetchAggregate(address, key)` — Returns the stored data or throws if not found
+- `AlephHttpClient` - Unauthenticated, for read-only operations
+- `fetchAggregate(address, key)` - Returns the stored data or throws if not found
 - Always validate the response shape before using it
 
 ## Writing Data
@@ -206,7 +206,7 @@ export async function saveProfile(
 1. Validate chain (must be mainnet)
 2. Wrap browser wallet → ethers5 → Aleph SDK adapters
 3. Create authenticated client with signing capability
-4. Call `createAggregate()` — this prompts the wallet popup
+4. Call `createAggregate()` - this prompts the wallet popup
 
 ## React Integration
 

--- a/docs/devhub/examples/clawdbot.md
+++ b/docs/devhub/examples/clawdbot.md
@@ -68,7 +68,7 @@ Get-Content $env:USERPROFILE\.ssh\id_ed25519.pub
 
 :::
 
-Copy the output — you'll paste this into the Aleph Dashboard in the next step.
+Copy the output - you'll paste this into the Aleph Dashboard in the next step.
 
 ### Step 3: Access the Aleph Dashboard
 
@@ -90,13 +90,13 @@ Click **+ Create Instance** and configure:
 
 Aleph Cloud uses a pay-as-you-go model with ALEPH tokens. Two options:
 
-**Option A — Hold Tokens (4,000 $ALEPH on Ethereum):**
+**Option A - Hold Tokens (4,000 $ALEPH on Ethereum):**
 
 - Purchase ALEPH tokens from exchanges (Uniswap, Coinbase, etc.)
 - Hold them in your wallet
-- You can sell them once you're done — no wasted tokens
+- You can sell them once you're done - no wasted tokens
 
-**Option B — Pay-as-you-go (on Base):**
+**Option B - Pay-as-you-go (on Base):**
 
 - Use ALEPH on Base network
 - Only pay for what you use (~$5/month for this spec)

--- a/docs/devhub/examples/index.md
+++ b/docs/devhub/examples/index.md
@@ -6,14 +6,14 @@ Hands-on tutorials for building on Aleph Cloud. Each guide walks through a real 
 
 ### [Aggregates Cookbook](./aggregates-cookbook)
 
-Store and sync user data on the Aleph network using the JavaScript SDK. Build a profile sync feature that loads and saves settings tied to a wallet address — no backend required.
+Store and sync user data on the Aleph network using the JavaScript SDK. Build a profile sync feature that loads and saves settings tied to a wallet address - no backend required.
 
 - **Stack:** TypeScript, React, wagmi
 - **Difficulty:** Intermediate
 
-### [Pasta Drop — Decentralized Pastebin](./pasta-drop)
+### [Pasta Drop - Decentralized Pastebin](./pasta-drop)
 
-Build a permanent pastebin powered by Aleph STORE messages. Paste text, sign with your wallet, and get an immutable link — no backend, no database, no expiration.
+Build a permanent pastebin powered by Aleph STORE messages. Paste text, sign with your wallet, and get an immutable link - no backend, no database, no expiration.
 
 - **Stack:** TypeScript, React, Aleph SDK, Reown AppKit
 - **Difficulty:** Intermediate

--- a/docs/nodes/resources/management/migration/index.md
+++ b/docs/nodes/resources/management/migration/index.md
@@ -12,7 +12,7 @@ Migration will cause a brief interruption. Schedule it during a low-activity win
 
 ## General Principles
 
-- **On-chain identity does not move with the server.** A node's identity is its Ethereum address registered in the node registry — that stays the same. What changes is the underlying machine serving traffic for that identity.
+- **On-chain identity does not move with the server.** A node's identity is its Ethereum address registered in the node registry - that stays the same. What changes is the underlying machine serving traffic for that identity.
 - **Keep the same public IP when possible.** Other nodes' P2P trust is tied to the IPv4 address and node keys. Migrating to the same IP is the smoothest path.
 - **Always back up before you migrate.** Treat the migration as a backup/restore exercise. See the [Backups guide](/nodes/resources/management/backups/) first.
 
@@ -22,32 +22,32 @@ Migration will cause a brief interruption. Schedule it during a low-activity win
 
 ### 1. Prepare backups on the old server
 
-Follow the [Backups guide](/nodes/resources/management/backups/) to capture what you need. There are two supported migration strategies — pick the one that fits your situation:
+Follow the [Backups guide](/nodes/resources/management/backups/) to capture what you need. There are two supported migration strategies - pick the one that fits your situation:
 
 #### Required (minimal migration)
 
 At a minimum, you **must** migrate:
 
-- **pyaleph P2P keys** — `pyaleph/keys/*` (critical: other nodes trust these keys; losing them is equivalent to creating a new node identity)
-- **`config.yml`** — your pyaleph configuration file
-- **`docker-compose.yml`** — and any customised overrides you maintain
+- **pyaleph P2P keys** - `pyaleph/keys/*` (critical: other nodes trust these keys; losing them is equivalent to creating a new node identity)
+- **`config.yml`** - your pyaleph configuration file
+- **`docker-compose.yml`** - and any customised overrides you maintain
 
 With only these files, the new node will come up with the correct identity and resynchronise **all** state from the network from scratch.
 
 - **Pros:** much smaller transfer; no risk of carrying over a corrupted database or stale file storage.
-- **Cons:** full resync typically takes **24 hours to one week** depending on CPU, disk, and network throughput. During resync the node is not serving fully, but **this does not impact your node score** — the score only penalises unresponsive or misconfigured nodes, not a node that is legitimately catching up.
+- **Cons:** full resync typically takes **24 hours to one week** depending on CPU, disk, and network throughput. During resync the node is not serving fully, but **this does not impact your node score** - the score only penalises unresponsive or misconfigured nodes, not a node that is legitimately catching up.
 
 #### Recommended (fast recovery)
 
 For the shortest downtime, also back up the data volumes in addition to the files above:
 
-- **PostgreSQL database** — Docker volume `pyaleph-postgres`
-- **pyaleph local storage** — Docker volume `pyaleph-local-storage`
-- **IPFS (Kubo) data** — Docker volume `pyaleph-ipfs`
+- **PostgreSQL database** - Docker volume `pyaleph-postgres`
+- **pyaleph local storage** - Docker volume `pyaleph-local-storage`
+- **IPFS (Kubo) data** - Docker volume `pyaleph-ipfs`
 
 With a recent, consistent copy of these volumes the new node can resume in minutes to hours rather than days. Ensure backups are consistent: either stop the node before snapshotting, or use a filesystem with atomic snapshots (BTRFS/ZFS/QCOW).
 
-#### IPFS identity (Kubo) — when to keep or regenerate
+#### IPFS identity (Kubo) - when to keep or regenerate
 
 The IPFS daemon (Kubo) has its own identity key, stored in the Kubo `config` file inside the `pyaleph-ipfs` volume, typically at:
 
@@ -57,8 +57,8 @@ The IPFS daemon (Kubo) has its own identity key, stored in the Kubo `config` fil
 
 Whether you should migrate this file depends on the new IP address:
 
-- **Same public IP on the new server** — back up and restore the Kubo `config` file so the IPFS peer ID stays the same. Other IPFS peers will continue to recognise your node without rebuilding connectivity.
-- **New public IP on the new server** — you can still keep the Kubo `config` if you want to, but it is not required. If the file is not migrated, Kubo will generate a fresh identity on first start. This is harmless: the IPFS network will discover your new peer ID automatically.
+- **Same public IP on the new server** - back up and restore the Kubo `config` file so the IPFS peer ID stays the same. Other IPFS peers will continue to recognise your node without rebuilding connectivity.
+- **New public IP on the new server** - you can still keep the Kubo `config` if you want to, but it is not required. If the file is not migrated, Kubo will generate a fresh identity on first start. This is harmless: the IPFS network will discover your new peer ID automatically.
 
 ### 2. Provision the new server
 
@@ -71,7 +71,7 @@ cd /path/to/pyaleph
 docker compose down
 ```
 
-Take a final incremental snapshot of the database and file storage at this point — this is the cleanest state to restore from.
+Take a final incremental snapshot of the database and file storage at this point - this is the cleanest state to restore from.
 
 ### 4. Transfer data to the new server
 
@@ -96,7 +96,7 @@ rsync -av /var/lib/docker/volumes/pyaleph_pyaleph-ipfs/ \
 
 Volume paths may differ depending on your Docker installation; verify with `docker volume inspect`.
 
-If you're keeping the **same public IP** and want to preserve the IPFS peer identity, the Kubo `config` file is already included when you rsync the whole `pyaleph-ipfs` volume — no extra step needed.
+If you're keeping the **same public IP** and want to preserve the IPFS peer identity, the Kubo `config` file is already included when you rsync the whole `pyaleph-ipfs` volume - no extra step needed.
 
 If you're using a **new IP** and want Kubo to regenerate its identity instead, exclude the config file during the rsync:
 
@@ -132,7 +132,7 @@ Verify:
 
 ### 7. Update the on-chain registration (multiaddress)
 
-A CCN is registered on-chain with a **multiaddress** that includes its public IP and libp2p peer ID. If the new server has a different IP, or you let the P2P identity change, you must update the registered multiaddress so other nodes and the network can reach you — otherwise your node will look unreachable and your score will drop.
+A CCN is registered on-chain with a **multiaddress** that includes its public IP and libp2p peer ID. If the new server has a different IP, or you let the P2P identity change, you must update the registered multiaddress so other nodes and the network can reach you - otherwise your node will look unreachable and your score will drop.
 
 **When you must update the multiaddress:**
 
@@ -141,7 +141,7 @@ A CCN is registered on-chain with a **multiaddress** that includes its public IP
 
 **When you can skip this step:**
 
-- Same public IPv4 **and** the P2P keys were migrated — the multiaddress is unchanged.
+- Same public IPv4 **and** the P2P keys were migrated - the multiaddress is unchanged.
 
 **Retrieve the new multiaddress** by querying the running node (replace `NODE_IP_ADDRESS` with the new public IP):
 
@@ -175,14 +175,14 @@ Only after the new node is confirmed synced and healthy:
 
 This section is hidden until the CRN migration procedure has been fully validated. Do not re-enable without review.
 
-CRNs hold less persistent state than CCNs — ephemeral VMs are rescheduled automatically, and most persistent instances can be re-fetched from the network. The important things to preserve are configuration, the domain name, and TLS.
+CRNs hold less persistent state than CCNs - ephemeral VMs are rescheduled automatically, and most persistent instances can be re-fetched from the network. The important things to preserve are configuration, the domain name, and TLS.
 
 ### 1. Back up CRN configuration
 
 On the old server, back up:
 
-- **`/etc/aleph-vm/supervisor.env`** — main aleph-vm configuration, including `ALEPH_VM_NETWORK_INTERFACE`, `ALEPH_VM_DOMAIN_NAME`, `PAYMENT_RECEIVER_ADDRESS`, and any GPU/confidential settings
-- **Reverse proxy configuration** — `/etc/caddy/Caddyfile` or `/etc/haproxy/haproxy.cfg`, plus any TLS certificates not managed by automatic renewal
+- **`/etc/aleph-vm/supervisor.env`** - main aleph-vm configuration, including `ALEPH_VM_NETWORK_INTERFACE`, `ALEPH_VM_DOMAIN_NAME`, `PAYMENT_RECEIVER_ADDRESS`, and any GPU/confidential settings
+- **Reverse proxy configuration** - `/etc/caddy/Caddyfile` or `/etc/haproxy/haproxy.cfg`, plus any TLS certificates not managed by automatic renewal
 - **Systemd overrides**, if any, under `/etc/systemd/system/aleph-vm-supervisor.service.d/`
 
 ### 2. Provision the new server
@@ -202,15 +202,15 @@ scp -r user@old-server:/etc/caddy/ /etc/caddy/     # or haproxy
 
 Review `supervisor.env` and update any hardware-specific settings on the new server:
 
-- `ALEPH_VM_NETWORK_INTERFACE` — the name of the network interface on the new host (e.g. `eth0`, `enp1s0`)
+- `ALEPH_VM_NETWORK_INTERFACE` - the name of the network interface on the new host (e.g. `eth0`, `enp1s0`)
 - Any path that referenced the old disk layout
 - GPU device IDs if GPU support is enabled
 
-The reward address (`PAYMENT_RECEIVER_ADDRESS`) and domain name should remain unchanged — they tie the node to its on-chain identity.
+The reward address (`PAYMENT_RECEIVER_ADDRESS`) and domain name should remain unchanged - they tie the node to its on-chain identity.
 
 ### 4. Update DNS
 
-Point your CRN domain's `A` and `AAAA` records at the new server's IP addresses. Wait for DNS propagation — the CRN's domain name is the identity that the scheduler and users rely on.
+Point your CRN domain's `A` and `AAAA` records at the new server's IP addresses. Wait for DNS propagation - the CRN's domain name is the identity that the scheduler and users rely on.
 
 If you use Let's Encrypt with automatic HTTP-01 challenges, the new server will need to obtain fresh certificates once DNS resolves. If you copied existing certificates, make sure the domain still matches.
 
@@ -249,11 +249,11 @@ You only need to update the registration if you are also changing the domain nam
 3. Locate your CRN and open its settings.
 4. Replace the address/URL with the new domain and save.
 
-If you kept the same domain, skip this step — the network already knows how to reach you through DNS.
+If you kept the same domain, skip this step - the network already knows how to reach you through DNS.
 
 ### 8. Persistent instances
 
-Persistent VMs scheduled on your CRN will need to be rescheduled by their owners or will be re-launched by the scheduler on the next tick — this is expected and part of the normal CRN lifecycle. Pay-as-you-go instances will continue streaming payments as long as the CRN remains reachable at the same domain.
+Persistent VMs scheduled on your CRN will need to be rescheduled by their owners or will be re-launched by the scheduler on the next tick - this is expected and part of the normal CRN lifecycle. Pay-as-you-go instances will continue streaming payments as long as the CRN remains reachable at the same domain.
 
 ### 9. Decommission the old server
 
@@ -276,7 +276,7 @@ Confirm the new node is fully operational for at least one scoring window, then 
 
 If the new node fails to sync or appears unhealthy:
 
-- Check firewall rules — CCN requires ports `4001` (IPv4 and IPv6) and `4025`.
+- Check firewall rules - CCN requires ports `4001` (IPv4 and IPv6) and `4025`.
 - Verify the P2P keys were copied correctly and have the right ownership/permissions.
 - Review logs with `docker compose logs`.
 - See the [Node Troubleshooting guide](/nodes/resources/management/troubleshooting/) for common issues.

--- a/docs/nodes/staking/index.md
+++ b/docs/nodes/staking/index.md
@@ -10,7 +10,7 @@ Staking is the heartbeat of our dynamic peer-to-peer network, driving security, 
 
 **Important:**
 
-- **Core Channel Nodes (CCN):** Users can only stake on CCNs—not on Compute Resource Nodes (CRNs).
+- **Core Channel Nodes (CCN):** Users can only stake on CCNs - not on Compute Resource Nodes (CRNs).
 - **Activation Requirement:** A CCN must accumulate a total of **500,000 ALEPH** in staked tokens to become active and eligible to receive rewards. Stakers will only receive rewards if the CCN’s total stake meets or exceeds this threshold.
 
 ---
@@ -51,6 +51,6 @@ Follow these step-by-step instructions to begin staking your Aleph tokens:
 
 ## Conclusion
 
-Staking with Aleph Cloud is more than just earning rewards—it's about actively participating in a decentralized ecosystem where you help govern the network. With auto-compounded rewards, flexible CCN selection, and a secure, **noncustodial process**, staking is an excellent way to grow your stake and support the future of a decentralized cloud.
+Staking with Aleph Cloud is more than just earning rewards - it's about actively participating in a decentralized ecosystem where you help govern the network. With auto-compounded rewards, flexible CCN selection, and a secure, **noncustodial process**, staking is an excellent way to grow your stake and support the future of a decentralized cloud.
 
 Join us today at [Aleph Cloud](https://app.aleph.cloud/account) and help shape the future of the Aleph Cloud network!


### PR DESCRIPTION
Sweep of the ~60 remaining em-dashes across the docs, all in files untouched by the Rust CLI migration:

- nodes/resources/management/migration/index.md (25)
- devhub/examples/aggregates-cookbook.md (10)
- devhub/deploying-and-hosting/automatic-domains/index.md (7)
- ARCHITECTURE.md (6)
- devhub/examples/clawdbot.md (4)
- devhub/examples/index.md (3)
- nodes/staking/index.md (2)
- about/use-cases/index.md (2)

All replaced with plain hyphens. Also fixes an "AAleph Cloud" typo in use-cases on a line already being edited.

Zero em-dashes remain in the docs. Build passes with `npx vitepress build docs`.