### PR TITLE
docs(cli): remove program persist/unpersist/logs stub commands

### DIFF
--- a/docs/devhub/compute-resources/functions/index.md
+++ b/docs/devhub/compute-resources/functions/index.md
@@ -113,8 +113,8 @@ To run the program in a persistent manner on the aleph.cloud network, use:
 aleph program create --persistent ./src/ main:app
 ```
 
-You can stop the execution of the program using:
+You can stop the execution of the program by deleting it:
 
 ```shell
-aleph program unpersist $MESSAGE_ID
+aleph program delete $ITEM_HASH
 ```

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/program.md
@@ -22,9 +22,6 @@ aleph program [OPTIONS] COMMAND [ARGS]...
 | `update`     | Update the code of an existing program                                  |
 | `delete`     | Forget a program (and its code STORE unless `--keep-code`)              |
 | `list`       | List programs owned by an address                                       |
-| `persist`    | Recreate a program with `persistent=true` (new item hash)               |
-| `unpersist`  | Recreate a program with `persistent=false` (new item hash)              |
-| `logs`       | Fetch logs from one CRN running this program                            |
 | `show`       | Show full information about a single program                            |
 
 ## Creating a Program
@@ -153,61 +150,6 @@ aleph program list
 aleph program list --address ADDRESS --json
 ```
 
-## Make a Program Persistent
-
-Recreate a non-persistent program as persistent (item hash will change). The program must be updatable.
-
-### Usage
-
-```bash
-aleph program persist [OPTIONS] <ITEM_HASH>
-```
-
-```bash
-# Recreate a non-persistent program as persistent
-aleph program persist ITEM_HASH
-```
-
-## Make a Program Non-Persistent
-
-Recreate a persistent program as non-persistent (item hash will change). The program must be updatable.
-
-### Usage
-
-```bash
-aleph program unpersist [OPTIONS] <ITEM_HASH>
-```
-
-```bash
-# Recreate a persistent program as non-persistent
-aleph program unpersist ITEM_HASH
-```
-
-## Display Logs of a Program
-
-Fetch logs from one CRN running this program. The `--crn` option is required: pass the URL of the CRN executing the program.
-
-### Usage
-
-```bash
-aleph program logs --crn <CRN_URL> <ITEM_HASH>
-```
-
-#### Options
-
-| Option                | Description                                         |
-| --------------------- | --------------------------------------------------- |
-| `--crn <CRN>`         | CRN URL (e.g. `https://crn.example.com`) [required]  |
-| `--account <NAME>`    | Named account (defaults to the active account)      |
-| `--private-key <KEY>` | Hex-encoded private key                             |
-| `--json`              | Output results as JSON                              |
-| `--help`              | Show this message and exit                          |
-
-```bash
-# Display logs of a program
-aleph program logs --crn https://crn.example.com ITEM_HASH
-```
-
 ## Supported Runtimes
 
 Aleph Cloud supports multiple programming languages. Use a preset slug (e.g. `python3.12`) or provide a 64-char item hash for a custom runtime. Omit `--runtime` to use the network's default runtime.
@@ -217,6 +159,5 @@ Aleph Cloud supports multiple programming languages. Use a preset slug (e.g. `py
 Common issues and solutions:
 
 - **Deployment failures**: Check your code for errors and ensure all dependencies are specified
-- **Runtime errors**: View logs with `aleph program logs --crn CRN_URL PROGRAM_HASH`
 - **Resource limitations**: Increase memory or CPU if your function is resource-intensive
 - **Timeout issues**: Optimize your code or increase the function timeout setting


### PR DESCRIPTION
`aleph program persist`, `aleph program unpersist`, and `aleph program logs` are stubs in the Rust CLI and do not work yet. This removes all references to them:

- **commands/program.md**: removed the `persist`/`unpersist`/`logs` rows from the key commands table, the three corresponding reference sections, and the troubleshooting bullet pointing at `program logs`
- **functions/index.md**: the "stop a persistent program" instruction now uses `aleph program delete` instead of `unpersist`

The `--persistent` flag on `aleph program create` is unaffected and stays documented.

Build passes with `npx vitepress build docs`.