### PR TITLE
docs(api): publish canonical endpoint matrix, remove dead API hosts

### DIFF
--- a/docs/devhub/api/rest.md
+++ b/docs/devhub/api/rest.md
@@ -11,13 +11,32 @@ Aleph Cloud provides a comprehensive REST API that allows developers to interact
 All API endpoints are available at:
 
 ```
-https://api.aleph.cloud/api/v0/
+https://api.aleph.im/api/v0/
 ```
 
-For development and testing, you can also use:
+As an alternative, you can also use:
 
 ```
-https://api1.aleph.cloud/api/v0/
+https://official.aleph.cloud/api/v0/
+```
+
+## Endpoint Matrix
+
+The canonical list of public Aleph Cloud service endpoints:
+
+| Service                            | URL                                              | Notes                                                                        |
+| ---------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Core Channel Node API (read/write) | `https://api.aleph.im`                           | Load-balanced. Primary endpoint for messages, aggregates, storage, balances. |
+| Core Channel Node API (alt)        | `https://official.aleph.cloud`                   | Same API; also serves node metrics.                                          |
+| Additional CCN mirrors             | `https://api2.aleph.im`, `https://api3.aleph.im` | Use for redundancy or load distribution.                                     |
+| VM Scheduler                       | `https://scheduler.api.aleph.cloud`              | `/api/v0/plan`, `/api/v0/allocation/{vm_hash}`, `/api/v0/nodes`.             |
+| Network status                     | `https://status.aleph.im`                        | `/api/services` for machine-readable health.                                 |
+| Credit API                         | `https://credit.aleph.im/api/v0`                 | `/payment` (paginated purchases), `/estimation/token-to-credit`.             |
+
+To quickly verify that the API is reachable:
+
+```bash
+curl https://api.aleph.im/api/v0/info/public.json
 ```
 
 ## Authentication
@@ -422,8 +441,8 @@ POST /run/{program_hash}
 
 #### Parameters
 
-| Parameter     | Type   | Description                        |
-| ------------- | ------ | ---------------------------------- |
+| Parameter      | Type   | Description                        |
+| -------------- | ------ | ---------------------------------- |
 | `program_hash` | string | The hash of the program to execute |
 
 #### Request Body
@@ -507,8 +526,8 @@ GET /instances/{instance_id}
 
 #### Parameters
 
-| Parameter    | Type   | Description                        |
-| ------------ | ------ | ---------------------------------- |
+| Parameter     | Type   | Description                        |
+| ------------- | ------ | ---------------------------------- |
 | `instance_id` | string | The ID of the instance to retrieve |
 
 #### Response

--- a/docs/devhub/sdks-and-tools/aleph-cli/commands/message.md
+++ b/docs/devhub/sdks-and-tools/aleph-cli/commands/message.md
@@ -197,12 +197,12 @@ aleph message sync [OPTIONS] --source <SOURCE> --target <TARGET>
 ```bash
 # Sync messages between two nodes
 aleph message sync \
-  --source https://api1.aleph.cloud \
-  --target https://api2.aleph.cloud
+  --source https://api.aleph.im \
+  --target https://api2.aleph.im
 
 # Dry-run to preview what would be synced
 aleph message sync \
-  --source https://api1.aleph.cloud \
-  --target https://api2.aleph.cloud \
+  --source https://api.aleph.im \
+  --target https://api2.aleph.im \
   --dry-run
 ```

--- a/docs/devhub/sdks-and-tools/python-sdk/index.md
+++ b/docs/devhub/sdks-and-tools/python-sdk/index.md
@@ -114,7 +114,7 @@ The `AuthenticatedAlephHttpClient` requires an `Account` object for signing mess
 ```python
 async with AuthenticatedAlephHttpClient(
     account=account,
-    api_server="https://api1.aleph.im",  # Optional
+    api_server="https://api.aleph.im",   # Optional
     api_unix_socket=None,               # Optional
     allow_unix_sockets=True,            # Optional
     timeout=None,                       # Optional
@@ -293,7 +293,7 @@ The `AlephHttpClient` class serves as the fundamental client for interacting wit
 
 ```python
 async with AlephHttpClient(
-    api_server="https://api1.aleph.im",  # Optional
+    api_server="https://api.aleph.im",   # Optional
     api_unix_socket=None,               # Optional
     allow_unix_sockets=True,            # Optional
     timeout=None,                       # Optional

--- a/docs/nodes/resources/management/monitoring/index.md
+++ b/docs/nodes/resources/management/monitoring/index.md
@@ -26,7 +26,7 @@ The main endpoints to monitor are:
 
 Examples:
 
-- Aleph CCN: [https://official.aleph.cloud/metrics](https://api.aleph.im/metrics)
+- Aleph CCN: [https://official.aleph.cloud/metrics](https://official.aleph.cloud/metrics)
 - Aleph Staging CRN: [https://ovh.staging.aleph.sh/status/check/fastapi](https://ovh.staging.aleph.sh/status/check/fastapi)
 
 ## Resource monitoring


### PR DESCRIPTION
Implements backlog item **P0-02**: canonical API endpoint matrix.

All endpoints were live-probed on 2026-06-10. Host verdicts:

- `api.aleph.cloud` — **DNS does not resolve**. Removed as documented base URL.
- `api1.aleph.cloud` — **TLS broken**. Removed as dev/testing endpoint.
- `api1.aleph.im` — **returns 404 on everything**. Replaced in SDK examples.

Changes:

- `docs/devhub/api/rest.md`: base URLs replaced with working hosts (`https://api.aleph.im` primary, `https://official.aleph.cloud` alternative); added a canonical endpoint matrix covering CCN API, mirrors, VM scheduler, status, and credit API; added a `curl https://api.aleph.im/api/v0/info/public.json` quick check.
- `docs/devhub/sdks-and-tools/python-sdk/index.md`: `api_server` examples now use `https://api.aleph.im`.
- `docs/nodes/resources/management/monitoring/index.md`: fixed mismatched link (text said `official.aleph.cloud/metrics`, URL pointed to `api.aleph.im/metrics`) — now consistently `official.aleph.cloud`.
- `docs/devhub/sdks-and-tools/aleph-cli/commands/message.md`: `aleph message sync` examples now use `https://api.aleph.im` / `https://api2.aleph.im` instead of dead `*.aleph.cloud` hosts.