### PR TITLE
docs(hosting): document auto-deployment on push with the GitHub Action

### DIFF
--- a/docs/devhub/deploying-and-hosting/web-hosting/index.md
+++ b/docs/devhub/deploying-and-hosting/web-hosting/index.md
@@ -133,7 +133,27 @@ Have a look to the [official documentation](https://docs.libertai.io/).
 
 ### Auto-Deployment on Push
 
-Coming soon.
+The [`aleph-im/web3-hosting-action`](https://github.com/aleph-im/web3-hosting-action) GitHub Action builds and deploys your website to Aleph Cloud automatically on every push, so your live site always tracks your repository.
+
+Add a step to your workflow after your build:
+
+```yaml
+- name: Deploy on Aleph
+  uses: aleph-im/web3-hosting-action@v2
+  with:
+    path: 'dist' # the folder containing your built static files
+    private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
+    domain: your-website.com # optional
+```
+
+The action covers the whole hosting workflow:
+
+- **Production deploys** on push: it uploads the build, registers a new version of your website (keeping the previous ones in its history), and repoints any attached [custom domain](#custom-domains) to the new release.
+- **Free pull request previews**: on `pull_request` events it deploys an anonymous, ephemeral preview (no wallet or credits needed) and comments the link on the PR. Previews are garbage-collected after a short grace period.
+- **Delegated deployments**: pass an `owner-address` to bill a single owner wallet that holds the credits and owns every site, while each repository signs with a low-privilege key authorized on its behalf — so a leaked CI key can't touch your funds. See the [delegated signing example](../../examples/static-site-deploy#optional-delegated-signing) for how the owner authorizes a signer.
+- **Retention**: set `retention_days` to automatically delete this website's older versions and stop paying to store them.
+
+See the [action's README](https://github.com/aleph-im/web3-hosting-action#readme) for the full list of inputs and outputs.
 
 ### Found an issue?
 

--- a/docs/devhub/deploying-and-hosting/web-hosting/index.md
+++ b/docs/devhub/deploying-and-hosting/web-hosting/index.md
@@ -149,7 +149,7 @@ Add a step to your workflow after your build:
 The action covers the whole hosting workflow:
 
 - **Production deploys** on push: it uploads the build, registers a new version of your website (keeping the previous ones in its history), and repoints any attached [custom domain](#custom-domains) to the new release.
-- **Free pull request previews**: on `pull_request` events it deploys an anonymous, ephemeral preview (no wallet or credits needed) and comments the link on the PR. Previews are garbage-collected after a short grace period.
+- **Pull request previews**: on `pull_request` events it deploys a preview of the build to a per-pull-request website and comments the link on the PR. Previews are signed with the same key (and `owner-address`, if you delegate) as production, and each one is removed automatically once its pull request is closed.
 - **Delegated deployments**: pass an `owner-address` to bill a single owner wallet that holds the credits and owns every site, while each repository signs with a low-privilege key authorized on its behalf — so a leaked CI key can't touch your funds. See the [delegated signing example](../../examples/static-site-deploy#optional-delegated-signing) for how the owner authorizes a signer.
 - **Retention**: set `retention_days` to automatically delete this website's older versions and stop paying to store them.
 


### PR DESCRIPTION
Fills in the **Auto-Deployment on Push** section of the Web3 Hosting page, which was a `Coming soon.` placeholder.

Documents the [`aleph-im/web3-hosting-action`](https://github.com/aleph-im/web3-hosting-action) GitHub Action (released as v2):
- Minimal `@v2` usage snippet (build → deploy, optional domain)
- Production deploys on push with version history + automatic custom-domain repointing
- Per-PR pull request previews, signed like production and removed automatically when the PR is closed
- Delegated deployments via `owner-address` (cross-linked to the delegated-signing cookbook)
- `retention_days` for cleaning up older versions

Cross-links use existing anchors on the page and in the static-site-deploy cookbook.