### PR TITLE
ci: add per-PR docs preview deployment to Aleph Cloud

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -31,7 +31,9 @@ permissions:
 jobs:
   deploy-preview:
     name: Deploy docs preview to Aleph Cloud
-    runs-on: ubuntu-22.04
+    # ubuntu-latest (24.04+): the aleph CLI binary the action installs needs a
+    # newer glibc (>= 2.38) than ubuntu-22.04 provides.
+    runs-on: ubuntu-latest
     # Fork PRs cannot read repository secrets, so the deploy would always fail.
     # Skip them cleanly instead of showing a red X on every external contribution.
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -39,10 +39,10 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: 'npm'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -39,10 +39,10 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'npm'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,59 @@
+name: PR preview deploy
+
+# Builds the docs and deploys a per-pull-request preview to Aleph Cloud using
+# aleph-im/web3-hosting-action@v2, commenting the preview link on the PR.
+#
+# Cleanup: on every pull_request event the action first sweeps this repo's
+# preview sites and removes the ones whose PR is now closed, then deploys the
+# current PR's preview. Closed-PR previews are therefore reaped on subsequent
+# PR activity - that is why we do NOT listen for the `closed` event (doing so
+# would make the action reap then immediately redeploy the just-closed preview).
+#
+# One-time setup required (delegated signing - the CI key signs, the owner
+# wallet pays and owns the sites):
+#   1. Generate a dedicated CI keypair; store its private key as the
+#      ALEPH_CI_PRIVATE_KEY repository secret.
+#   2. From the owner wallet, authorize the CI signer (low privilege - cannot
+#      spend credits, only manage website/domain registry entries):
+#        aleph authorization add <CI_SIGNER_ADDRESS> \
+#          --message-types store,aggregate \
+#          --aggregate-keys websites,domains \
+#          --channels ALEPH-CLOUDSOLUTIONS
+#   3. Ensure the owner wallet holds Aleph credits (`aleph credit buy`).
+#   4. Set the ALEPH_OWNER_ADDRESS repository variable to the owner address.
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write # comment the preview link and query PR state for cleanup
+
+jobs:
+  deploy-preview:
+    name: Deploy docs preview to Aleph Cloud
+    runs-on: ubuntu-22.04
+    # Fork PRs cannot read repository secrets, so the deploy would always fail.
+    # Skip them cleanly instead of showing a red X on every external contribution.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and Export
+        run: npm run docs:build
+
+      - name: Deploy preview on Aleph
+        uses: aleph-im/web3-hosting-action@v2
+        with:
+          path: docs/.vitepress/dist
+          private-key: ${{ secrets.ALEPH_CI_PRIVATE_KEY }}
+          owner-address: ${{ vars.ALEPH_OWNER_ADDRESS }}


### PR DESCRIPTION
Adds a `pull_request`-triggered workflow (`.github/workflows/pr-preview.yml`) that builds the docs and deploys a per-PR preview to Aleph Cloud via [`aleph-im/web3-hosting-action@v2`](https://github.com/aleph-im/web3-hosting-action), implementing the auto-deployment flow documented in #77. Release deployment is left unchanged.

## Design choices

- **Delegated signing**: signs with a low-privilege CI key (`ALEPH_CI_PRIVATE_KEY` secret) while the owner wallet (`ALEPH_OWNER_ADDRESS` variable) holds the credits and owns the sites. A leaked CI key cannot spend funds; its authorization is scoped to `store,aggregate` on the `websites,domains` aggregates only.
- **No `closed` trigger**: the action sweeps and removes previews of closed PRs at the start of every run, so cleanup happens through ongoing PR activity. Listening for `closed` would make it reap then immediately redeploy the just-closed preview.
- **Fork-PR guard**: fork PRs cannot read repository secrets, so they are skipped cleanly instead of failing on every external contribution.
- **Build steps mirror the existing release workflow** (Node 18, `npm install`, `npm run docs:build`, output at `docs/.vitepress/dist`).

## Required configuration (already set up)

- Secret `ALEPH_CI_PRIVATE_KEY`: dedicated CI signer key.
- Variable `ALEPH_OWNER_ADDRESS`: owner wallet address (must hold credits).
- One-time delegation from the owner wallet authorizing the CI signer (see comment block at the top of the workflow file).

## Notes

- Broken links do not fail the build in CI (matches existing release behavior); a link-check gate would be a separate change.
- This PR is itself the first live test of the preview deploy.
