### PR TITLE
docs(nodes): require a dedicated, routed, unique IPv6 /64 for CRNs

### DIFF
--- a/docs/nodes/compute/installation/debian-12/index.md
+++ b/docs/nodes/compute/installation/debian-12/index.md
@@ -108,8 +108,8 @@ Assuming your provider routes a `/64` to your host, the procedure is:
 
 > ⚠️ **Each node needs its own unique, routed /64.** The network scoring forces the score of any
 > node that shares its IPv6 `/64` with another node to `0` (diagnostic code `1005`, _duplicate IP_).
-> When several nodes sit in the same `/64` — common on shared-subnet providers, or when running
-> multiple nodes at the same host — only one of them is scored and the rest drop to zero.
+> When several nodes sit in the same `/64` (common on shared-subnet providers, or when running
+> multiple nodes at the same host), only one of them is scored and the rest drop to zero.
 
 > ⚠️ **Do not leave the default pool.** If `ALEPH_VM_IPV6_ADDRESS_POOL` is unset, aleph-vm falls
 > back to the placeholder `fc00:1:2:3::/64`. This is a private (ULA) range used only for
@@ -124,7 +124,7 @@ After setting the pool and restarting aleph-vm, confirm it is correct:
    ```
    curl -s https://vm.example.org/status/config | jq .networking.IPV6_ADDRESS_POOL
    ```
-   It must show **your** `/64` — not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
+   It must show **your** `/64`, not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
 2. Confirm the range is globally routable: it should start with a global-unicast prefix
    (`2000::/3`), not `fc00::/7` (ULA) or `fe80::/10` (link-local).
 3. From a machine **outside** your host, ping the IPv6 of one of your running VMs to confirm the

--- a/docs/nodes/compute/installation/debian-12/index.md
+++ b/docs/nodes/compute/installation/debian-12/index.md
@@ -19,7 +19,7 @@ In order to run an official Aleph Cloud Compute Resource Node (CRN), you will al
   - For [confidential computing](/nodes/compute/advanced/confidential/), specific AMD EPYC™ processors are required
 - RAM: 64GB
 - STORAGE: 1TB (NVMe SSD preferred, datacenter fast HDD possible under conditions, you’ll want a big and fast cache)
-- NETWORK: Minimum 500 Mbit/s symmetrical, dedicated IPv4, and /64 or larger IPv6 subnet.
+- NETWORK: Minimum 500 Mbit/s symmetrical, a dedicated IPv4, and a dedicated, routed IPv6 /64 (or larger) that is **not shared with any other node**.
 
 You will need a public domain name with access to add TXT and wildcard records.
 
@@ -82,10 +82,15 @@ ALEPH_VM_DOMAIN_NAME=vm.example.org
 
 #### IPv6 address pool
 
-Each virtual machine receives its own ipv6, the range of IPv6 addresses usable by the virtual machines must be specified manually.
+Each virtual machine receives its own publicly routable IPv6 address, taken from a pool you must
+configure manually. aleph-vm assigns each VM a `/124` sub-range carved from this pool.
 
-According to the IPv6 specifications, a system is expected to receive an IPv6 with a /64
-mask and all addresses inside that mask should simply be routed to the host.
+The pool **must be a globally-routable `/64` that is routed to your host and unique to this node**.
+According to the IPv6 specifications, a host is expected to receive a `/64` with every address
+inside it routed to the machine. Many providers follow this; some budget VPS providers instead
+place many customers on a single shared `/64` subnet and hand each machine only one address. That
+setup does **not** work for a node: the addresses assigned to your VMs would collide with other
+machines on the subnet, and your node will be penalized by the network scoring (see below).
 
 The option takes the form of:
 
@@ -93,11 +98,37 @@ The option takes the form of:
 ALEPH_VM_IPV6_ADDRESS_POOL="2a01:4f8:171:787::/64"
 ```
 
-Assuming your hosting provider follows the specification, the procedure is the following:
+Assuming your provider routes a `/64` to your host, the procedure is:
 
-1. Obtain the IPv6 address of your node.
-2. Remove the trailing number after `::` if present, for example `2a01:4f8:171:787::2/64` becomes `2a01:4f8:171:787::/64`.
-3. Add the IPv6 range you obtained under the setting `ALEPH_VM_IPV6_ADDRESS_POOL` in the configuration.
+1. Obtain the routed IPv6 `/64` assigned to your node. If your provider only gives you a single
+   address on a shared subnet, ask them for a _routed_ (or _delegated_) `/64`.
+2. Remove the trailing host bits after `::` if present, for example `2a01:4f8:171:787::2/64`
+   becomes `2a01:4f8:171:787::/64`.
+3. Add the range under the setting `ALEPH_VM_IPV6_ADDRESS_POOL` in the configuration.
+
+> ⚠️ **Each node needs its own unique, routed /64.** The network scoring forces the score of any
+> node that shares its IPv6 `/64` with another node to `0` (diagnostic code `1005`, _duplicate IP_).
+> When several nodes sit in the same `/64` — common on shared-subnet providers, or when running
+> multiple nodes at the same host — only one of them is scored and the rest drop to zero.
+
+> ⚠️ **Do not leave the default pool.** If `ALEPH_VM_IPV6_ADDRESS_POOL` is unset, aleph-vm falls
+> back to the placeholder `fc00:1:2:3::/64`. This is a private (ULA) range used only for
+> compatibility with hosts not yet configured for IPv6: your VMs receive non-routable addresses
+> and have no working public IPv6. Always set the pool to your own routed `/64`.
+
+##### Verifying your IPv6 pool
+
+After setting the pool and restarting aleph-vm, confirm it is correct:
+
+1. Check the value your node reports (replace the domain with your own):
+   ```
+   curl -s https://vm.example.org/status/config | jq .networking.IPV6_ADDRESS_POOL
+   ```
+   It must show **your** `/64` — not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
+2. Confirm the range is globally routable: it should start with a global-unicast prefix
+   (`2000::/3`), not `fc00::/7` (ULA) or `fe80::/10` (link-local).
+3. From a machine **outside** your host, ping the IPv6 of one of your running VMs to confirm the
+   `/64` is actually routed to you: `ping6 <vm-ipv6-address>`.
 
 #### Network Interface
 

--- a/docs/nodes/compute/installation/ubuntu-24.04/index.md
+++ b/docs/nodes/compute/installation/ubuntu-24.04/index.md
@@ -108,8 +108,8 @@ Assuming your provider routes a `/64` to your host, the procedure is:
 
 > ⚠️ **Each node needs its own unique, routed /64.** The network scoring forces the score of any
 > node that shares its IPv6 `/64` with another node to `0` (diagnostic code `1005`, _duplicate IP_).
-> When several nodes sit in the same `/64` — common on shared-subnet providers, or when running
-> multiple nodes at the same host — only one of them is scored and the rest drop to zero.
+> When several nodes sit in the same `/64` (common on shared-subnet providers, or when running
+> multiple nodes at the same host), only one of them is scored and the rest drop to zero.
 
 > ⚠️ **Do not leave the default pool.** If `ALEPH_VM_IPV6_ADDRESS_POOL` is unset, aleph-vm falls
 > back to the placeholder `fc00:1:2:3::/64`. This is a private (ULA) range used only for
@@ -124,7 +124,7 @@ After setting the pool and restarting aleph-vm, confirm it is correct:
    ```
    curl -s https://vm.example.org/status/config | jq .networking.IPV6_ADDRESS_POOL
    ```
-   It must show **your** `/64` — not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
+   It must show **your** `/64`, not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
 2. Confirm the range is globally routable: it should start with a global-unicast prefix
    (`2000::/3`), not `fc00::/7` (ULA) or `fe80::/10` (link-local).
 3. From a machine **outside** your host, ping the IPv6 of one of your running VMs to confirm the

--- a/docs/nodes/compute/installation/ubuntu-24.04/index.md
+++ b/docs/nodes/compute/installation/ubuntu-24.04/index.md
@@ -19,7 +19,7 @@ In order to run an official Aleph Cloud Compute Resource Node (CRN), you will al
   - For [confidential computing](/nodes/compute/advanced/confidential/), specific AMD EPYC™ processors are required
 - RAM: 64GB
 - STORAGE: 1TB (NVMe SSD preferred, datacenter fast HDD possible under conditions, you’ll want a big and fast cache)
-- NETWORK: Minimum 500 Mbit/s symmetrical, dedicated IPv4, and /64 or larger IPv6 subnet.
+- NETWORK: Minimum 500 Mbit/s symmetrical, a dedicated IPv4, and a dedicated, routed IPv6 /64 (or larger) that is **not shared with any other node**.
 
 You will need a public domain name with access to add TXT and wildcard records.
 
@@ -82,11 +82,15 @@ ALEPH_VM_DOMAIN_NAME=vm.example.org
 
 #### IPv6 address pool
 
-Each virtual machine receives its own ipv6, the range of IPv6 addresses usable by the virtual machines must be specified
-manually.
+Each virtual machine receives its own publicly routable IPv6 address, taken from a pool you must
+configure manually. aleph-vm assigns each VM a `/124` sub-range carved from this pool.
 
-According to the IPv6 specifications, a system is expected to receive an IPv6 with a /64
-mask and all addresses inside that mask should simply be routed to the host.
+The pool **must be a globally-routable `/64` that is routed to your host and unique to this node**.
+According to the IPv6 specifications, a host is expected to receive a `/64` with every address
+inside it routed to the machine. Many providers follow this; some budget VPS providers instead
+place many customers on a single shared `/64` subnet and hand each machine only one address. That
+setup does **not** work for a node: the addresses assigned to your VMs would collide with other
+machines on the subnet, and your node will be penalized by the network scoring (see below).
 
 The option takes the form of:
 
@@ -94,12 +98,37 @@ The option takes the form of:
 ALEPH_VM_IPV6_ADDRESS_POOL="2a01:4f8:171:787::/64"
 ```
 
-Assuming your hosting provider follows the specification, the procedure is the following:
+Assuming your provider routes a `/64` to your host, the procedure is:
 
-1. Obtain the IPv6 address of your node.
-2. Remove the trailing number after `::` if present, for example `2a01:4f8:171:787::2/64` becomes
-   `2a01:4f8:171:787::/64`.
-3. Add the IPv6 range you obtained under the setting `ALEPH_VM_IPV6_ADDRESS_POOL` in the configuration.
+1. Obtain the routed IPv6 `/64` assigned to your node. If your provider only gives you a single
+   address on a shared subnet, ask them for a _routed_ (or _delegated_) `/64`.
+2. Remove the trailing host bits after `::` if present, for example `2a01:4f8:171:787::2/64`
+   becomes `2a01:4f8:171:787::/64`.
+3. Add the range under the setting `ALEPH_VM_IPV6_ADDRESS_POOL` in the configuration.
+
+> ⚠️ **Each node needs its own unique, routed /64.** The network scoring forces the score of any
+> node that shares its IPv6 `/64` with another node to `0` (diagnostic code `1005`, _duplicate IP_).
+> When several nodes sit in the same `/64` — common on shared-subnet providers, or when running
+> multiple nodes at the same host — only one of them is scored and the rest drop to zero.
+
+> ⚠️ **Do not leave the default pool.** If `ALEPH_VM_IPV6_ADDRESS_POOL` is unset, aleph-vm falls
+> back to the placeholder `fc00:1:2:3::/64`. This is a private (ULA) range used only for
+> compatibility with hosts not yet configured for IPv6: your VMs receive non-routable addresses
+> and have no working public IPv6. Always set the pool to your own routed `/64`.
+
+##### Verifying your IPv6 pool
+
+After setting the pool and restarting aleph-vm, confirm it is correct:
+
+1. Check the value your node reports (replace the domain with your own):
+   ```
+   curl -s https://vm.example.org/status/config | jq .networking.IPV6_ADDRESS_POOL
+   ```
+   It must show **your** `/64` — not `fc00:1:2:3::/64`, and not a `/64` shared with other machines.
+2. Confirm the range is globally routable: it should start with a global-unicast prefix
+   (`2000::/3`), not `fc00::/7` (ULA) or `fe80::/10` (link-local).
+3. From a machine **outside** your host, ping the IPv6 of one of your running VMs to confirm the
+   `/64` is actually routed to you: `ping6 <vm-ipv6-address>`.
 
 #### Network Interface
 


### PR DESCRIPTION
## Why

Two node operators recently saw their CRN scores drop to **0** despite running v1.13.0 and being otherwise healthy. Root cause in both cases: multiple CRNs sharing one IPv6 `/64`, which trips the scoring system's duplicate-IP gate (diagnostic code `1005`) — only one node per shared `/64` is scored, the rest are zeroed.

- **Cluster A** (NOHAVPS, ASN 63025): 13 nodes in `2602:f8ea:0:ae1::/64`; two independently-verified nodes advertised the *identical* pool.
- **Cluster B** (Meria, Scaleway): 15 nodes spread across 4 shared `/64` subnets; **14 of 15 still ran the default `fc00:1:2:3::/64`**, so their VMs got non-routable ULA addresses and no working public IPv6.

The existing install docs were partly responsible: they told operators to *derive* the pool from their node's address and strip it to a `/64`. On shared-subnet providers that yields a `/64` the node doesn't exclusively own — exactly the misconfiguration above. Nothing warned about uniqueness, the scoring penalty, or the placeholder default.

## What changed

Updated **both** CRN install guides (`ubuntu-24.04` and `debian-12`, which carry duplicated content):

- **Requirement line:** the IPv6 `/64` must be *dedicated, routed, and not shared with any other node*.
- **Rewrote the "IPv6 address pool" section:** the pool must be a globally-routable `/64` routed to the host and unique to the node; added a shared-subnet-provider warning.
- **Scoring warning:** sharing a `/64` zeroes the score (code `1005`).
- **Default-pool warning:** an unset `ALEPH_VM_IPV6_ADDRESS_POOL` falls back to the non-routable ULA placeholder `fc00:1:2:3::/64` (verified against aleph-vm `conf.py`).
- **New "Verifying your IPv6 pool" subsection:** check `/status/config`, confirm global-unicast prefix, and ping a VM's IPv6 from outside.

All technical claims verified against `aleph-vm` source and live node `/status/config` data.

## Note

The two install guides duplicate this IPv6 content verbatim; this PR keeps them in sync but does not address the underlying duplication. Worth a follow-up to factor shared install steps into a partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)